### PR TITLE
Docs: HA MQTT discovery setup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to HIRI
+
+Thank you for your interest in contributing to HIRI — the Home Assistant bridge + ESP32/ESP8266 farmware + web/admin/mobile smart-home stack.
+
+## Monorepo Structure
+
+This repository is organized as a monorepo with the following packages:
+
+| Package   | Path               | Description                                      |
+|-----------|--------------------|--------------------------------------------------|
+| `bridge`  | `packages/bridge/` | Python Home Assistant bridge (MQTT, discovery)   |
+| `admin`   | `packages/admin/`  | Web admin interface                              |
+| `web`     | `packages/web/`    | Main web frontend                                |
+| `android` | `packages/android/`| Android mobile app                               |
+| `ios`     | `packages/ios/`    | iOS mobile app                                   |
+| `firmware`| `packages/firmware/`| ESP32/ESP8266 firmware (PlatformIO)             |
+
+## Getting Started
+
+1. **Fork** the repository on GitHub.
+2. **Clone** your fork:
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/HIRI.git
+   cd HIRI
+   ```
+3. **Set up your environment** per the package you want to contribute to (see each package's README).
+
+## How to Contribute
+
+- **Report bugs** by opening a GitHub Issue.
+- **Suggest features** by opening a GitHub Issue with the `enhancement` label.
+- **Submit code** via a Pull Request (see below).
+
+## Pull Request Process
+
+1. Create a feature branch from `master`:
+   ```bash
+   git checkout -b feat/my-feature
+   ```
+2. Make your changes, keeping them focused on a single concern.
+3. Run existing tests for the affected package(s).
+4. Commit with a clear message:
+   ```
+   feat(bridge): add MQTT auto-reconnect
+   ```
+5. Push to your fork and open a Pull Request against `master`.
+6. Link any related issues in the PR description using `Closes #N`.
+
+## Code Style
+
+- **Python** (bridge): follows PEP 8 — run `ruff check` before committing.
+- **C++** (firmware): follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
+- **JavaScript/TypeScript** (web/admin): follows the project's ESLint configuration.
+
+## Need Help?
+
+Open a [Discussion](https://github.com/mergeos-bounties/HIRI/discussions) or ask in the relevant issue. We're happy to guide new contributors!

--- a/docs/mqtt-discovery-setup.md
+++ b/docs/mqtt-discovery-setup.md
@@ -1,0 +1,68 @@
+# HA MQTT Discovery Setup Guide
+
+This guide explains how to set up MQTT discovery for Home Assistant integration.
+
+## Prerequisites
+
+- Home Assistant instance (2024.6+)
+- MQTT broker (Mosquitto recommended)
+- Network connectivity between HA and MQTT broker
+
+## Configuration
+
+### 1. MQTT Broker Setup
+
+```yaml
+# configuration.yaml
+mqtt:
+  broker: 192.168.1.100
+  port: 1883
+  discovery: true
+  discovery_prefix: homeassistant
+```
+
+### 2. Discovery Message Format
+
+MQTT discovery uses the following topic structure:
+
+```
+<discovery_prefix>/<component>/<node_id>/<object_id>/config
+```
+
+Example for a sensor:
+
+```json
+{
+  "name": "Temperature Sensor",
+  "state_topic": "home/sensor/temperature",
+  "unit_of_measurement": "°C",
+  "device_class": "temperature"
+}
+```
+
+### 3. Supported Components
+
+- `sensor` — readings and measurements
+- `binary_sensor` — on/off states
+- `switch` — controllable relays
+- `light` — dimmable and RGB lights
+- `cover` — blinds and curtains
+- `climate` — thermostats and HVAC
+
+### 4. Testing Discovery
+
+Publish a test discovery message:
+
+```bash
+mosquitto_pub -h 192.168.1.100 \
+  -t "homeassistant/sensor/test/config" \
+  -m '{"name":"Test","state_topic":"test/state"}'
+```
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Device not discovered | Check `discovery: true` in MQTT config |
+| Wrong prefix | Verify `discovery_prefix` matches device configuration |
+| No MQTT connection | Test with `mosquitto_pub` from HA server |


### PR DESCRIPTION
## Changes

Added comprehensive MQTT discovery setup guide for Home Assistant integration.

## Content

- MQTT broker configuration
- Discovery message format
- Supported components list
- Testing instructions
- Troubleshooting table

Closes #1