### PR TITLE
Improve fan discovery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Primary offline path: **bridge** (`hiri-bridge demo`).
 
 | Capability | Description |
 | --- | --- |
-| **Device registry** | Seed + import devices; domains (light, sensor, …) |
+| **Device registry** | Seed + import devices; domains (light, fan, sensor, …) |
 | **HA discovery** | Export MQTT discovery payloads offline |
 | **Adapters** | local, z2m, tuya, ha_rest, mqtt, matter (scaffold) |
 | **MQTT dry-run** | Publish discovery without a live broker |
-| **Command demo** | Apply sample commands (brightness, effects) in-memory |
+| **Command demo** | Apply sample commands (brightness, effects, fan presets) in-memory |
 
 ---
 

--- a/packages/bridge/src/hiri_bridge/ha/discovery.py
+++ b/packages/bridge/src/hiri_bridge/ha/discovery.py
@@ -69,6 +69,9 @@ def discovery_payload(device: Device) -> dict:
     if domain == "fan":
         base["percentage"] = True
         base["preset_modes"] = device.attributes.get("preset_modes", ["low", "medium", "high"])
+        base["percentage_command_topic"] = command_topic(device)
+        base["preset_mode_command_topic"] = command_topic(device) + "/preset"
+        base["preset_mode_state_topic"] = state_topic(device) + "/preset"
     if domain == "sensor":
         base["unit_of_measurement"] = device.attributes.get("unit_of_measurement", "")
         base["device_class"] = device.attributes.get("device_class")

--- a/packages/bridge/tests/test_registry.py
+++ b/packages/bridge/tests/test_registry.py
@@ -39,6 +39,18 @@ def test_cover_tilt_and_fan_preset(tmp_path: Path) -> None:
     assert fan.state["state"] == "on"
 
 
+def test_fan_discovery_includes_preset_controls(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    fan = reg.get("fan.ceiling_lr")
+    assert fan is not None
+    payload = export_discovery([fan])[0]["payload"]
+    assert payload["preset_modes"] == ["low", "medium", "high", "breeze"]
+    assert payload["percentage_command_topic"].endswith("/cmd/fan/ceiling_lr")
+    assert payload["preset_mode_command_topic"].endswith("/cmd/fan/ceiling_lr/preset")
+    assert payload["preset_mode_state_topic"].endswith("/state/fan/ceiling_lr/preset")
+
+
 def test_discovery_export(tmp_path: Path) -> None:
     reg = DeviceRegistry(path=tmp_path / "devices.json")
     reg.seed()


### PR DESCRIPTION
Fixes #28

Adds fan preset control support to HIRI bridge discovery payloads, keeps command handling aligned with the seeded fan devices, and updates the README domains table.

Evidence:
- `pytest packages/bridge/tests/test_registry.py packages/bridge/tests/test_adapters.py -q`
- `ruff check src tests`
- fan discovery now includes preset-mode fields for supported fan devices in bridge discovery payloads

Validation:
- /tmp/hiri-venv/bin/pytest packages/bridge/tests/test_registry.py packages/bridge/tests/test_adapters.py -q
- /tmp/hiri-venv/bin/ruff check src tests

Claim references:
- issue: https://github.com/mergeos-bounties/HIRI/issues/28
- MergeOS claim token: https://github.com/mergeos-bounties/mergeos/issues/1