### PR TITLE
[25 MRG] Device pack: climate thermostat presets (Fixes #25)

### DIFF
--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -83,6 +83,25 @@ def default_seed_devices() -> list[Device]:
             attributes={"tilt": True, "device_class": "blind"},
         ),
         Device(
+            id="climate.living_thermostat",
+            name="Living room thermostat",
+            domain="climate",
+            model="HIRI-THERMO",
+            area="living",
+            state={
+                "hvac_mode": "heat",
+                "temperature": 21,
+                "current_temperature": 19,
+                "preset_mode": "comfort",
+            },
+            attributes={
+                "hvac_modes": ["off", "heat", "cool", "auto"],
+                "min_temp": 7,
+                "max_temp": 35,
+                "preset_modes": ["comfort", "eco", "away", "boost"],
+            },
+        ),
+        Device(
             id="cover.garage",
             name="Garage door",
             domain="cover",

--- a/packages/bridge/src/hiri_bridge/ha/discovery.py
+++ b/packages/bridge/src/hiri_bridge/ha/discovery.py
@@ -60,6 +60,13 @@ def discovery_payload(device: Device) -> dict:
         base["max_temp"] = device.attributes.get("max_temp", 30)
         base["temp_step"] = 0.5
         base["current_temperature_topic"] = state_topic(device)
+        base["mode_command_topic"] = command_topic(device) + "/mode"
+        base["temperature_command_topic"] = command_topic(device) + "/temp"
+        preset_modes = device.attributes.get("preset_modes")
+        if preset_modes:
+            base["preset_modes"] = preset_modes
+            base["preset_mode_command_topic"] = command_topic(device) + "/preset"
+            base["preset_mode_state_topic"] = state_topic(device) + "/preset"
     if domain == "cover":
         base["command_topic"] = command_topic(device)
         base["position_topic"] = state_topic(device) + "/position"
@@ -94,12 +101,6 @@ def discovery_payload(device: Device) -> dict:
         base["payload_unlock"] = "UNLOCK"
         base["state_locked"] = "LOCKED"
         base["state_unlocked"] = "UNLOCKED"
-    if domain == "climate":
-        base["mode_command_topic"] = command_topic(device) + "/mode"
-        base["temperature_command_topic"] = command_topic(device) + "/temp"
-        base["modes"] = ["off", "cool", "heat", "auto"]
-        base["min_temp"] = 16
-        base["max_temp"] = 30
     if domain == "number":
         base["command_topic"] = command_topic(device)
         base["min"] = device.attributes.get("min", 0)

--- a/packages/bridge/tests/test_climate_pack.py
+++ b/packages/bridge/tests/test_climate_pack.py
@@ -1,0 +1,50 @@
+"""Device pack tests: climate — thermostat presets (Fixes #25)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.ha.discovery import export_discovery
+
+
+def test_climate_seed_present(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    stats = reg.stats()
+    assert stats["by_domain"].get("climate", 0) >= 2
+    thermo = reg.get("climate.living_thermostat")
+    assert thermo is not None
+    assert thermo.attributes["preset_modes"] == ["comfort", "eco", "away", "boost"]
+
+
+def test_climate_command_sets_mode_temp_and_preset(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command(
+        "climate.living_thermostat",
+        "set_temperature",
+        {"hvac_mode": "cool", "temperature": 23, "preset_mode": "eco"},
+    )
+    assert dev.state["hvac_mode"] == "cool"
+    assert dev.state["temperature"] == 23
+    assert dev.state["preset_mode"] == "eco"
+
+
+def test_climate_discovery_includes_presets_and_topics(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    thermo = reg.get("climate.living_thermostat")
+    assert thermo is not None
+    payload = export_discovery([thermo])[0]["payload"]
+
+    assert payload["modes"] == ["off", "heat", "cool", "auto"]
+    assert payload["min_temp"] == 7
+    assert payload["max_temp"] == 35
+    assert payload["temp_step"] == 0.5
+    # thermostat presets must be advertised for HA
+    assert payload["preset_modes"] == ["comfort", "eco", "away", "boost"]
+    assert payload["preset_mode_command_topic"].endswith("/cmd/climate/living_thermostat/preset")
+    assert payload["preset_mode_state_topic"].endswith("/state/climate/living_thermostat/preset")
+    assert payload["mode_command_topic"].endswith("/cmd/climate/living_thermostat/mode")
+    assert payload["temperature_command_topic"].endswith("/cmd/climate/living_thermostat/temp")


### PR DESCRIPTION
## Summary
Expands **climate** support in HIRI-bridge with thermostat presets, as requested in #25.

While implementing I found the HA discovery builder had **two conflicting `if domain == "climate"` blocks** — the second overwrote the first, so `preset_modes` from the device attributes were never emitted (thermostat presets silently dropped). This PR consolidates them into a single correct block and wires presets through.

## Changes
- `ha/discovery.py` — merge the duplicate climate blocks; emit `preset_modes`, `preset_mode_command_topic`, `preset_mode_state_topic`, `mode_command_topic`, `temperature_command_topic` when the device advertises presets
- `devices/registry.py` — add `climate.living_thermostat` seed device (HIRI-THERMO) with a richer preset state (`comfort`/`eco`/`away`/`boost`)
- `tests/test_climate_pack.py` — seed presence, command coverage (mode + temp + preset), and discovery-payload preset/topic assertions
- `README.md` — note climate thermostat presets in the command-demo highlight

## Tested
```
$ pytest tests/test_climate_pack.py tests/test_registry.py -q
8 passed
$ pytest tests/ -q
15 passed, 2 skipped
```

## Acceptance
- [x] Tests pass
- [x] `hiri-bridge ha discovery` includes climate (with preset fields)
- [x] Web can show the device when bridge is running (seed device in default registry)

## Gate 1
Both core repos starred: `mergeos-bounties/HIRI` + `mergeos-bounties/mergeos`.

Fixes #25