### PR TITLE
[25 MRG] Device pack: cover tilt blinds (Fixes #26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Primary offline path: **bridge** (`hiri-bridge demo`).
 | **HA discovery** | Export MQTT discovery payloads offline |
 | **Adapters** | local, z2m, tuya, ha_rest, mqtt, matter (scaffold) |
 | **MQTT dry-run** | Publish discovery without a live broker |
-| **Command demo** | Apply sample commands (brightness, effects, fan presets) in-memory |
+| **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt) in-memory |
 
 ---
 

--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -74,6 +74,15 @@ def default_seed_devices() -> list[Device]:
             },
         ),
         Device(
+            id="cover.living_blinds",
+            name="Living room blinds",
+            domain="cover",
+            model="HIRI-BLIND",
+            area="living",
+            state={"state": "open", "position": 100, "tilt": 50},
+            attributes={"tilt": True, "device_class": "blind"},
+        ),
+        Device(
             id="cover.garage",
             name="Garage door",
             domain="cover",

--- a/packages/bridge/src/hiri_bridge/ha/discovery.py
+++ b/packages/bridge/src/hiri_bridge/ha/discovery.py
@@ -61,11 +61,19 @@ def discovery_payload(device: Device) -> dict:
         base["temp_step"] = 0.5
         base["current_temperature_topic"] = state_topic(device)
     if domain == "cover":
-        base["position_topic"] = state_topic(device)
+        base["command_topic"] = command_topic(device)
+        base["position_topic"] = state_topic(device) + "/position"
         base["set_position_topic"] = command_topic(device)
         base["payload_open"] = "OPEN"
         base["payload_close"] = "CLOSE"
         base["payload_stop"] = "STOP"
+        base["position_open"] = 100
+        base["position_closed"] = 0
+        if device.attributes.get("tilt"):
+            base["tilt_status_topic"] = state_topic(device) + "/tilt"
+            base["tilt_command_topic"] = command_topic(device) + "/tilt"
+            base["tilt_min"] = 0
+            base["tilt_max"] = 100
     if domain == "fan":
         base["percentage"] = True
         base["preset_modes"] = device.attributes.get("preset_modes", ["low", "medium", "high"])
@@ -86,12 +94,6 @@ def discovery_payload(device: Device) -> dict:
         base["payload_unlock"] = "UNLOCK"
         base["state_locked"] = "LOCKED"
         base["state_unlocked"] = "UNLOCKED"
-    if domain == "cover":
-        base["command_topic"] = command_topic(device)
-        base["payload_open"] = "OPEN"
-        base["payload_close"] = "CLOSE"
-        base["payload_stop"] = "STOP"
-        base["position_topic"] = state_topic(device) + "/position"
     if domain == "climate":
         base["mode_command_topic"] = command_topic(device) + "/mode"
         base["temperature_command_topic"] = command_topic(device) + "/temp"

--- a/packages/bridge/tests/test_cover_pack.py
+++ b/packages/bridge/tests/test_cover_pack.py
@@ -1,0 +1,51 @@
+"""Device pack tests: cover — tilt blinds (Fixes #26)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.ha.discovery import export_discovery
+
+
+def test_cover_tilt_seed_present(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    stats = reg.stats()
+    assert stats["by_domain"].get("cover", 0) >= 2
+    blinds = reg.get("cover.living_blinds")
+    assert blinds is not None
+    assert blinds.attributes["tilt"] is True
+
+
+def test_cover_command_set_tilt_and_position(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("cover.living_blinds", "set_tilt", {"tilt": 30})
+    assert dev.state["tilt"] == 30
+    dev = reg.apply_command("cover.living_blinds", "set_position", {"position": 75})
+    assert dev.state["position"] == 75
+    assert dev.state["state"] == "open"
+
+
+def test_cover_discovery_includes_tilt_topics(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    blinds = reg.get("cover.living_blinds")
+    assert blinds is not None
+    payload = export_discovery([blinds])[0]["payload"]
+
+    assert payload["position_topic"].endswith("/state/cover/living_blinds/position")
+    assert payload["tilt_status_topic"].endswith("/state/cover/living_blinds/tilt")
+    assert payload["tilt_command_topic"].endswith("/cmd/cover/living_blinds/tilt")
+    assert payload["tilt_min"] == 0
+    assert payload["tilt_max"] == 100
+
+
+def test_cover_without_tilt_omits_tilt_topics(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    garage = reg.get("cover.garage")
+    assert garage is not None
+    payload = export_discovery([garage])[0]["payload"]
+    assert "tilt_command_topic" not in payload


### PR DESCRIPTION
## Summary
Expands **cover** support in HIRI-bridge with tilt blinds, as requested in #26.

Same latent bug as the climate domain: the HA discovery builder had **two conflicting `if domain == "cover"` blocks** with divergent `position_topic` values, and `set_tilt` was already handled in the registry command path but **tilt was never advertised in discovery**. This PR consolidates the blocks and emits tilt topics for cover devices that declare tilt support.

## Changes
- `ha/discovery.py` — merge the duplicate cover blocks; add `position_open`/`position_closed` and, for tilt-capable covers, `tilt_status_topic`, `tilt_command_topic`, `tilt_min`, `tilt_max`
- `devices/registry.py` — add `cover.living_blinds` seed device (HIRI-BLIND, `tilt: True`, `device_class: blind`)
- `tests/test_cover_pack.py` — seed presence, command coverage (set_tilt + set_position), tilt discovery topics, and a negative test that non-tilt covers omit tilt topics
- `README.md` — note cover tilt in the command-demo highlight

## Tested
```
$ pytest tests/test_cover_pack.py -q
4 passed
$ pytest tests/ -q
16 passed, 2 skipped
```

## Acceptance
- [x] Tests pass
- [x] `hiri-bridge ha discovery` includes cover (with tilt fields)
- [x] Web can show the device when bridge is running (seed device in default registry)

## Gate 1
Both core repos starred: `mergeos-bounties/HIRI` + `mergeos-bounties/mergeos`.

Fixes #26