### PR TITLE
[25 MRG] Device pack: lock PIN/door codes (Fixes #27)

### DIFF
--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -118,6 +118,19 @@ def default_seed_devices() -> list[Device]:
             state={"state": "locked"},
         ),
         Device(
+            id="lock.side_gate",
+            name="Side gate keypad",
+            domain="lock",
+            model="HIRI-KEYPAD",
+            area="garden",
+            state={"state": "locked", "code_set": False},
+            attributes={
+                "code_required": True,
+                "code_format": "^[0-9]{4,6}$",
+                "supported_features": ["lock", "unlock", "open"],
+            },
+        ),
+        Device(
             id="fan.ceiling_lr",
             name="Ceiling fan",
             domain="fan",
@@ -543,8 +556,12 @@ class DeviceRegistry:
                 state["state"] = "locked"
             elif action == "unlock":
                 state["state"] = "unlocked"
+            elif action == "open":
+                state["state"] = "open"
             if "code" in data:
                 state["last_code_set"] = bool(data["code"])
+                if "code_set" in state:
+                    state["code_set"] = bool(data["code"])
         elif domain == "cover":
             if action == "open":
                 state["state"] = "open"

--- a/packages/bridge/src/hiri_bridge/ha/discovery.py
+++ b/packages/bridge/src/hiri_bridge/ha/discovery.py
@@ -101,6 +101,11 @@ def discovery_payload(device: Device) -> dict:
         base["payload_unlock"] = "UNLOCK"
         base["state_locked"] = "LOCKED"
         base["state_unlocked"] = "UNLOCKED"
+        if device.attributes.get("code_required"):
+            # PIN/door-code stub: HA expects a code_format regex and a
+            # dedicated topic reporting whether a code was set locally.
+            base["code_format"] = device.attributes.get("code_format", "^[0-9]{4,8}$")
+            base["code_state_topic"] = state_topic(device) + "/code"
     if domain == "number":
         base["command_topic"] = command_topic(device)
         base["min"] = device.attributes.get("min", 0)

--- a/packages/bridge/tests/test_lock_pack.py
+++ b/packages/bridge/tests/test_lock_pack.py
@@ -1,0 +1,50 @@
+"""Device pack tests: lock — PIN / door codes stub (Fixes #27)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.ha.discovery import export_discovery
+
+
+def test_lock_keypad_seed_present(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    stats = reg.stats()
+    assert stats["by_domain"].get("lock", 0) >= 2
+    gate = reg.get("lock.side_gate")
+    assert gate is not None
+    assert gate.attributes["code_required"] is True
+
+
+def test_lock_command_lock_unlock_and_code(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("lock.side_gate", "unlock", {"code": "1234"})
+    assert dev.state["state"] == "unlocked"
+    assert dev.state["code_set"] is True
+    dev = reg.apply_command("lock.side_gate", "lock")
+    assert dev.state["state"] == "locked"
+
+
+def test_lock_keypad_discovery_includes_code_format(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    gate = reg.get("lock.side_gate")
+    assert gate is not None
+    payload = export_discovery([gate])[0]["payload"]
+
+    assert payload["payload_lock"] == "LOCK"
+    assert payload["payload_unlock"] == "UNLOCK"
+    assert payload["code_format"] == "^[0-9]{4,6}$"
+    assert payload["code_state_topic"].endswith("/state/lock/side_gate/code")
+
+
+def test_lock_without_code_omits_code_format(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    front = reg.get("lock.front")
+    assert front is not None
+    payload = export_discovery([front])[0]["payload"]
+    assert "code_format" not in payload


### PR DESCRIPTION
## Summary
Expands **lock** support in HIRI-bridge with a PIN / door-code stub, as requested in #27.

The registry command path already tracked a code flag, but HA discovery never advertised a `code_format`, so keypad locks couldn't prompt for a PIN. This PR wires a code-format regex + code state topic through discovery for locks that declare `code_required`, and adds a keypad seed device.

## Changes
- `ha/discovery.py` — for `code_required` locks, emit `code_format` (regex) and `code_state_topic`
- `devices/registry.py` — add `lock.side_gate` keypad seed (HIRI-KEYPAD, `code_required`, `^[0-9]{4,6}$`); handle `open` action and sync a `code_set` flag when a code is supplied
- `tests/test_lock_pack.py` — seed presence, lock/unlock/code command coverage, code_format discovery, and a negative test that codeless locks omit `code_format`
- `README.md` — note lock PIN codes in the command-demo highlight

## Tested
```
$ pytest tests/test_lock_pack.py -q
4 passed
$ pytest tests/ -q
16 passed, 2 skipped
```

## Acceptance
- [x] Tests pass
- [x] `hiri-bridge ha discovery` includes lock (with code_format for keypads)
- [x] Web can show the device when bridge is running (seed device in default registry)

## Gate 1
Both core repos starred: `mergeos-bounties/HIRI` + `mergeos-bounties/mergeos`.

Fixes #27