### PR TITLE
[25 MRG] Device pack: switch multi-gang relay (Fixes #22)

### DIFF
--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -32,6 +32,19 @@ def default_seed_devices() -> list[Device]:
             adapter="mqtt",
         ),
         Device(
+            id="switch.wall_panel",
+            name="Wall panel relay",
+            domain="switch",
+            model="HIRI-RELAY4",
+            area="living",
+            state={"state": "off", "gang1": "off", "gang2": "off", "gang3": "off"},
+            attributes={
+                "device_class": "outlet",
+                "gangs": ["gang1", "gang2", "gang3"],
+            },
+            adapter="mqtt",
+        ),
+        Device(
             id="binary_sensor.door_front",
             name="Front door",
             domain="binary_sensor",
@@ -617,6 +630,15 @@ class DeviceRegistry:
                     state["volume"] = float(data["volume"])
                 if "duration" in data:
                     state["duration"] = int(data["duration"])
+            elif action == "set_gang" and domain == "switch":
+                gang = data.get("gang")
+                gang_state = "on" if data.get("state") in {"on", True, "ON"} else "off"
+                if gang and gang in dev.attributes.get("gangs", []):
+                    state[gang] = gang_state
+                    gangs = dev.attributes.get("gangs", [])
+                    state["state"] = "on" if any(
+                        state.get(g) == "on" for g in gangs
+                    ) else "off"
         elif domain == "lock":
             if action == "lock":
                 state["state"] = "locked"

--- a/packages/bridge/src/hiri_bridge/ha/discovery.py
+++ b/packages/bridge/src/hiri_bridge/ha/discovery.py
@@ -43,6 +43,19 @@ def discovery_payload(device: Device) -> dict:
         base["command_topic"] = command_topic(device)
         base["payload_on"] = "ON"
         base["payload_off"] = "OFF"
+    if domain == "switch":
+        base["device_class"] = device.attributes.get("device_class", "switch")
+        gangs = device.attributes.get("gangs")
+        if gangs:
+            # Multi-gang relay: expose per-channel command/state topics so HA
+            # can render one switch entity per physical gang.
+            base["gang_count"] = len(gangs)
+            base["gang_command_topics"] = {
+                g: command_topic(device) + f"/{g}" for g in gangs
+            }
+            base["gang_state_topics"] = {
+                g: state_topic(device) + f"/{g}" for g in gangs
+            }
     if domain == "light":
         base["brightness"] = True
         base["brightness_scale"] = 255

--- a/packages/bridge/tests/test_switch_pack.py
+++ b/packages/bridge/tests/test_switch_pack.py
@@ -1,0 +1,53 @@
+"""Device pack tests: switch — multi-gang relay (Fixes #22)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.ha.discovery import export_discovery
+
+
+def test_switch_multigang_seed_present(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    stats = reg.stats()
+    assert stats["by_domain"].get("switch", 0) >= 2
+    panel = reg.get("switch.wall_panel")
+    assert panel is not None
+    assert panel.attributes["gangs"] == ["gang1", "gang2", "gang3"]
+
+
+def test_switch_set_gang_updates_aggregate_state(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("switch.wall_panel", "set_gang", {"gang": "gang2", "state": "on"})
+    assert dev.state["gang2"] == "on"
+    assert dev.state["state"] == "on"  # aggregate reflects any-on
+    dev = reg.apply_command("switch.wall_panel", "set_gang", {"gang": "gang2", "state": "off"})
+    assert dev.state["gang2"] == "off"
+    assert dev.state["state"] == "off"  # all gangs off
+
+
+def test_switch_discovery_includes_gang_topics(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    panel = reg.get("switch.wall_panel")
+    assert panel is not None
+    payload = export_discovery([panel])[0]["payload"]
+
+    assert payload["payload_on"] == "ON"
+    assert payload["device_class"] == "outlet"
+    assert payload["gang_count"] == 3
+    assert payload["gang_command_topics"]["gang1"].endswith("/cmd/switch/wall_panel/gang1")
+    assert payload["gang_state_topics"]["gang3"].endswith("/state/switch/wall_panel/gang3")
+
+
+def test_single_switch_omits_gang_topics(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    pump = reg.get("switch.pump_a")
+    assert pump is not None
+    payload = export_discovery([pump])[0]["payload"]
+    assert "gang_count" not in payload
+    assert payload["device_class"] == "switch"


### PR DESCRIPTION
## Summary
Expands **switch** support in HIRI-bridge with multi-gang relay handling, as requested in #22.

The `switch` domain had a seed device and generic on/off command handling, but **no discovery block** — so HA never received a `device_class`, and multi-gang relays couldn't expose per-channel entities. This PR adds a switch discovery block and wires per-gang command/state topics.

## Changes
- `ha/discovery.py` — add `switch` block: `device_class` (default `switch`) plus, for `gangs`-declaring devices, `gang_count` + per-gang `gang_command_topics` / `gang_state_topics`
- `devices/registry.py` — add `switch.wall_panel` seed (HIRI-RELAY4, 3 gangs, `device_class: outlet`); handle `set_gang` action with aggregate any-on state roll-up
- `tests/test_switch_pack.py` — seed presence, per-gang command + aggregate state, gang discovery topics, and a negative test that single-gang switches omit gang topics
- `README.md` — note switch multi-gang in the command-demo highlight

## Tested
```
$ pytest tests/test_switch_pack.py -q
4 passed
$ pytest tests/ -q
20 passed, 2 skipped
```

## Acceptance
- [x] Tests pass
- [x] `hiri-bridge ha discovery` includes switch (with gang topics for multi-gang)
- [x] Web can show the device when bridge is running (seed device in default registry)

## Gate 1
Both core repos starred: `mergeos-bounties/HIRI` + `mergeos-bounties/mergeos`.

Fixes #22