### PR TITLE
[25 MRG] Device pack: siren tones (Fixes #35)

### DIFF
--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -225,7 +225,12 @@ def default_seed_devices() -> list[Device]:
             domain="siren",
             model="HIRI-SIREN",
             area="home",
-            state={"state": "off"},
+            state={"state": "off", "tone": None, "volume": 1.0},
+            attributes={
+                "available_tones": ["alarm", "chime", "fire", "burglar"],
+                "support_duration": True,
+                "support_volume_set": True,
+            },
         ),
         Device(
             id="humidifier.bedroom",
@@ -597,6 +602,16 @@ class DeviceRegistry:
                 if mode in dev.attributes.get("modes", []):
                     state["mode"] = mode
                     state["state"] = "on"
+            elif action == "set_tone" and domain == "siren":
+                tones = dev.attributes.get("available_tones", [])
+                tone = data.get("tone")
+                if tone in tones:
+                    state["tone"] = tone
+                    state["state"] = "on"
+                if "volume" in data:
+                    state["volume"] = float(data["volume"])
+                if "duration" in data:
+                    state["duration"] = int(data["duration"])
         elif domain == "lock":
             if action == "lock":
                 state["state"] = "locked"

--- a/packages/bridge/src/hiri_bridge/ha/discovery.py
+++ b/packages/bridge/src/hiri_bridge/ha/discovery.py
@@ -97,6 +97,14 @@ def discovery_payload(device: Device) -> dict:
             base["modes"] = modes
             base["mode_command_topic"] = command_topic(device) + "/mode"
             base["mode_state_topic"] = state_topic(device) + "/mode"
+    if domain == "siren":
+        tones = device.attributes.get("available_tones")
+        if tones:
+            # HA siren entity: advertise selectable tones + support flags so
+            # the frontend renders a tone picker alongside on/off.
+            base["available_tones"] = tones
+            base["support_duration"] = device.attributes.get("support_duration", True)
+            base["support_volume_set"] = device.attributes.get("support_volume_set", True)
     if domain == "sensor":
         base["unit_of_measurement"] = device.attributes.get("unit_of_measurement", "")
         dev_class = device.attributes.get("device_class")

--- a/packages/bridge/tests/test_siren_pack.py
+++ b/packages/bridge/tests/test_siren_pack.py
@@ -1,0 +1,45 @@
+"""Device pack tests: siren — tones (Fixes #35)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.ha.discovery import export_discovery
+
+
+def test_siren_seed_has_tones(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    siren = reg.get("siren.alarm")
+    assert siren is not None
+    assert "fire" in siren.attributes["available_tones"]
+
+
+def test_siren_set_tone_and_volume(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("siren.alarm", "set_tone", {"tone": "chime", "volume": 0.5})
+    assert dev.state["tone"] == "chime"
+    assert dev.state["state"] == "on"
+    assert dev.state["volume"] == 0.5
+
+
+def test_siren_rejects_unknown_tone(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("siren.alarm", "set_tone", {"tone": "nonexistent"})
+    assert dev.state["tone"] is None  # unchanged, invalid tone ignored
+
+
+def test_siren_discovery_includes_available_tones(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    siren = reg.get("siren.alarm")
+    assert siren is not None
+    payload = export_discovery([siren])[0]["payload"]
+
+    assert payload["payload_on"] == "ON"
+    assert payload["available_tones"] == ["alarm", "chime", "fire", "burglar"]
+    assert payload["support_duration"] is True
+    assert payload["support_volume_set"] is True


### PR DESCRIPTION
## Summary
Expands **siren** support in HIRI-bridge with selectable tones, as requested in #35.

The `siren` domain had a seed device and generic on/off, but **no discovery block** — so HA never received `available_tones` and couldn't render a tone picker. This PR adds a siren discovery block plus tone/volume/duration command handling.

## Changes
- `ha/discovery.py` — add `siren` block: for devices declaring `available_tones`, emit `available_tones`, `support_duration`, `support_volume_set`
- `devices/registry.py` — enrich `siren.alarm` seed (tones: alarm/chime/fire/burglar, volume, support flags); handle `set_tone` action with tone validation + volume/duration
- `tests/test_siren_pack.py` — seed tones, set_tone + volume, invalid-tone rejection, and discovery tone advertisement
- `README.md` — note siren tones in the command-demo highlight

## Tested
```
$ pytest tests/test_siren_pack.py -q
4 passed
$ pytest tests/ -q
20 passed, 2 skipped
```

## Acceptance
- [x] Tests pass
- [x] `hiri-bridge ha discovery` includes siren (with available_tones)
- [x] Web can show the device when bridge is running (seed device in default registry)

## Gate 1
Both core repos starred: `mergeos-bounties/HIRI` + `mergeos-bounties/mergeos`.

Fixes #35