### PR TITLE
[25 MRG] Device pack: humidifier modes (Fixes #36)

### DIFF
--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -184,7 +184,12 @@ def default_seed_devices() -> list[Device]:
             domain="humidifier",
             model="HIRI-HUM",
             area="bedroom",
-            state={"state": "off", "humidity": 55},
+            state={"state": "off", "humidity": 55, "target_humidity": 50, "mode": "normal"},
+            attributes={
+                "modes": ["normal", "eco", "away", "sleep", "boost"],
+                "min_humidity": 30,
+                "max_humidity": 80,
+            },
         ),
         Device(
             id="water_heater.boiler",
@@ -519,6 +524,17 @@ class DeviceRegistry:
             elif action == "set_preset_mode" and domain == "fan":
                 state["preset_mode"] = data.get("preset_mode", "low")
                 state["state"] = "on"
+            elif action == "set_humidity" and domain == "humidifier":
+                lo = dev.attributes.get("min_humidity", 30)
+                hi = dev.attributes.get("max_humidity", 80)
+                target = int(data.get("humidity", 50))
+                state["target_humidity"] = max(lo, min(hi, target))
+                state["state"] = "on"
+            elif action == "set_mode" and domain == "humidifier":
+                mode = data.get("mode")
+                if mode in dev.attributes.get("modes", []):
+                    state["mode"] = mode
+                    state["state"] = "on"
         elif domain == "lock":
             if action == "lock":
                 state["state"] = "locked"

--- a/packages/bridge/src/hiri_bridge/ha/discovery.py
+++ b/packages/bridge/src/hiri_bridge/ha/discovery.py
@@ -80,6 +80,16 @@ def discovery_payload(device: Device) -> dict:
         base["percentage_command_topic"] = command_topic(device)
         base["preset_mode_command_topic"] = command_topic(device) + "/preset"
         base["preset_mode_state_topic"] = state_topic(device) + "/preset"
+    if domain == "humidifier":
+        base["target_humidity_command_topic"] = command_topic(device) + "/humidity"
+        base["current_humidity_topic"] = state_topic(device) + "/current_humidity"
+        base["min_humidity"] = device.attributes.get("min_humidity", 30)
+        base["max_humidity"] = device.attributes.get("max_humidity", 80)
+        modes = device.attributes.get("modes")
+        if modes:
+            base["modes"] = modes
+            base["mode_command_topic"] = command_topic(device) + "/mode"
+            base["mode_state_topic"] = state_topic(device) + "/mode"
     if domain == "sensor":
         base["unit_of_measurement"] = device.attributes.get("unit_of_measurement", "")
         base["device_class"] = device.attributes.get("device_class")

--- a/packages/bridge/tests/test_humidifier_pack.py
+++ b/packages/bridge/tests/test_humidifier_pack.py
@@ -1,0 +1,46 @@
+"""Device pack tests: humidifier — modes (Fixes #36)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.ha.discovery import export_discovery
+
+
+def test_humidifier_seed_has_modes(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    hum = reg.get("humidifier.bedroom")
+    assert hum is not None
+    assert "eco" in hum.attributes["modes"]
+
+
+def test_humidifier_set_humidity_clamped_to_range(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("humidifier.bedroom", "set_humidity", {"humidity": 95})
+    assert dev.state["target_humidity"] == 80  # clamped to max_humidity
+    assert dev.state["state"] == "on"
+
+
+def test_humidifier_set_mode_validated(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("humidifier.bedroom", "set_mode", {"mode": "sleep"})
+    assert dev.state["mode"] == "sleep"
+    dev2 = reg.apply_command("humidifier.bedroom", "set_mode", {"mode": "bogus"})
+    assert dev2.state["mode"] == "sleep"  # unchanged, invalid mode ignored
+
+
+def test_humidifier_discovery_includes_modes_and_range(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    hum = reg.get("humidifier.bedroom")
+    assert hum is not None
+    payload = export_discovery([hum])[0]["payload"]
+
+    assert payload["payload_on"] == "ON"
+    assert payload["min_humidity"] == 30
+    assert payload["max_humidity"] == 80
+    assert payload["modes"] == ["normal", "eco", "away", "sleep", "boost"]


### PR DESCRIPTION
## Summary
Expands **humidifier** support in HIRI-bridge with mode selection, as requested in #36.

The `humidifier` domain had a bare seed device and only generic on/off, but **no discovery block** — so HA never received `min_humidity`/`max_humidity`/`modes`. This PR adds a humidifier discovery block plus target-humidity and mode command handling.

## Changes
- `ha/discovery.py` — add `humidifier` block: `target_humidity_command_topic`, `current_humidity_topic`, `min_humidity`/`max_humidity`, and (when declared) `modes` + mode topics
- `devices/registry.py` — enrich `humidifier.bedroom` seed (modes: normal/eco/away/sleep/boost, humidity range 30-80); handle `set_humidity` (clamped to range) and `set_mode` (validated against declared modes)
- `tests/test_humidifier_pack.py` — seed modes, humidity clamping, mode validation (rejects invalid), and discovery range/modes
- `README.md` — note humidifier modes in the command-demo highlight

## Tested
```
$ pytest tests/test_humidifier_pack.py -q
4 passed
$ pytest tests/ -q
20 passed, 2 skipped
```

## Acceptance
- [x] Tests pass
- [x] `hiri-bridge ha discovery` includes humidifier (with modes + humidity range)
- [x] Web can show the device when bridge is running (seed device in default registry)

## Gate 1
Both core repos starred: `mergeos-bounties/HIRI` + `mergeos-bounties/mergeos`.

Fixes #36