### PR TITLE
[25 MRG] Device pack: binary_sensor battery + off_delay (Fixes #23)

### DIFF
--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -41,6 +41,20 @@ def default_seed_devices() -> list[Device]:
             attributes={"device_class": "door"},
         ),
         Device(
+            id="binary_sensor.window_bedroom",
+            name="Bedroom window",
+            domain="binary_sensor",
+            model="HIRI-CONTACT-BAT",
+            area="bedroom",
+            state={"state": "off", "battery": 87},
+            attributes={
+                "device_class": "window",
+                "battery": True,
+                "expire_after": 3600,
+            },
+            adapter="mqtt",
+        ),
+        Device(
             id="sensor.soil_moisture_1",
             name="Soil moisture bed 1",
             domain="sensor",
@@ -275,7 +289,7 @@ def default_seed_devices() -> list[Device]:
             model="HIRI-PIR",
             area="entry",
             state={"state": "off"},
-            attributes={"device_class": "motion"},
+            attributes={"device_class": "motion", "off_delay": 30},
             adapter="mqtt",
         ),
         Device(

--- a/packages/bridge/src/hiri_bridge/ha/discovery.py
+++ b/packages/bridge/src/hiri_bridge/ha/discovery.py
@@ -88,6 +88,15 @@ def discovery_payload(device: Device) -> dict:
         base["device_class"] = device.attributes.get("device_class", "opening")
         base["payload_on"] = "ON"
         base["payload_off"] = "OFF"
+        if "off_delay" in device.attributes:
+            # Auto-clear after N seconds (e.g. motion/PIR sensors)
+            base["off_delay"] = device.attributes["off_delay"]
+        if "expire_after" in device.attributes:
+            base["expire_after"] = device.attributes["expire_after"]
+        if device.attributes.get("battery"):
+            # Battery-powered contact: expose a JSON attributes topic so HA
+            # can surface the battery level reported alongside the state.
+            base["json_attributes_topic"] = state_topic(device) + "/attributes"
     if domain == "lock":
         base["command_topic"] = command_topic(device)
         base["payload_lock"] = "LOCK"

--- a/packages/bridge/tests/test_binary_sensor_pack.py
+++ b/packages/bridge/tests/test_binary_sensor_pack.py
@@ -1,0 +1,50 @@
+"""Device pack tests: binary_sensor — door/window/battery (Fixes #23)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.ha.discovery import export_discovery
+
+
+def test_battery_window_seed_present(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    win = reg.get("binary_sensor.window_bedroom")
+    assert win is not None
+    assert win.attributes["battery"] is True
+    assert win.state["battery"] == 87
+
+
+def test_motion_sensor_has_off_delay(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    motion = next(
+        d for d in reg.list() if d.domain == "binary_sensor" and d.attributes.get("device_class") == "motion"
+    )
+    assert motion.attributes["off_delay"] == 30
+
+
+def test_battery_sensor_discovery_has_attributes_topic(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    win = reg.get("binary_sensor.window_bedroom")
+    assert win is not None
+    payload = export_discovery([win])[0]["payload"]
+
+    assert payload["device_class"] == "window"
+    assert payload["expire_after"] == 3600
+    assert payload["json_attributes_topic"].endswith("/attributes")
+
+
+def test_plain_door_sensor_omits_battery_fields(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    door = reg.get("binary_sensor.door_front")
+    assert door is not None
+    payload = export_discovery([door])[0]["payload"]
+
+    assert payload["device_class"] == "door"
+    assert "json_attributes_topic" not in payload
+    assert "off_delay" not in payload


### PR DESCRIPTION
## Summary
Expands **binary_sensor** support in HIRI-bridge with battery reporting and auto-clear, as requested in #23.

The `binary_sensor` domain had several seeds (door/window/motion/smoke/leak) but the discovery block only emitted `device_class` + on/off payloads — no `off_delay` for auto-clearing motion sensors, no `expire_after`, and no way to surface a battery level. This PR wires those through and adds a battery-powered contact seed.

## Changes
- `ha/discovery.py` — binary_sensor block now emits `off_delay` and `expire_after` when declared, plus `json_attributes_topic` for battery-powered devices
- `devices/registry.py` — add `binary_sensor.window_bedroom` seed (battery 87%, window class, expire_after 3600); give the PIR motion seed `off_delay: 30`
- `tests/test_binary_sensor_pack.py` — battery seed presence, motion off_delay, battery discovery attributes topic, and a negative test that plain door sensors omit battery/off-delay fields
- `README.md` — note binary_sensor battery/off-delay in the command-demo highlight

## Tested
```
$ pytest tests/test_binary_sensor_pack.py -q
4 passed
$ pytest tests/ -q
20 passed, 2 skipped
```

## Acceptance
- [x] Tests pass
- [x] `hiri-bridge ha discovery` includes binary_sensor (with battery + off_delay)
- [x] Web can show the device when bridge is running (seed devices in default registry)

## Gate 1
Both core repos starred: `mergeos-bounties/HIRI` + `mergeos-bounties/mergeos`.

Fixes #23