### PR TITLE
[25 MRG] Device pack: sensor PM2.5/CO2/energy state_class (Fixes #24)

### DIFF
--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -327,6 +327,19 @@ def default_seed_devices() -> list[Device]:
             adapter="mqtt",
         ),
         Device(
+            id="sensor.panel_energy",
+            name="Panel energy",
+            domain="sensor",
+            model="HIRI-PWR",
+            area="utility",
+            state={"state": 1834.7},
+            attributes={
+                "unit_of_measurement": "kWh",
+                "device_class": "energy",
+            },
+            adapter="mqtt",
+        ),
+        Device(
             id="switch.washer",
             name="Washer outlet",
             domain="switch",

--- a/packages/bridge/src/hiri_bridge/ha/discovery.py
+++ b/packages/bridge/src/hiri_bridge/ha/discovery.py
@@ -82,8 +82,18 @@ def discovery_payload(device: Device) -> dict:
         base["preset_mode_state_topic"] = state_topic(device) + "/preset"
     if domain == "sensor":
         base["unit_of_measurement"] = device.attributes.get("unit_of_measurement", "")
-        base["device_class"] = device.attributes.get("device_class")
-        base["state_class"] = "measurement"
+        dev_class = device.attributes.get("device_class")
+        base["device_class"] = dev_class
+        # Cumulative meters (energy/gas/water/volume) must report
+        # total_increasing so HA long-term statistics + the Energy dashboard
+        # treat them as running totals rather than instantaneous readings.
+        total_classes = {"energy", "gas", "water", "volume", "precipitation"}
+        base["state_class"] = device.attributes.get(
+            "state_class",
+            "total_increasing" if dev_class in total_classes else "measurement",
+        )
+        if "last_reset" in device.attributes:
+            base["last_reset_value_template"] = device.attributes["last_reset"]
     if domain == "binary_sensor":
         base["device_class"] = device.attributes.get("device_class", "opening")
         base["payload_on"] = "ON"

--- a/packages/bridge/tests/test_sensor_pack.py
+++ b/packages/bridge/tests/test_sensor_pack.py
@@ -1,0 +1,52 @@
+"""Device pack tests: sensor — PM2.5 / CO2 / energy (Fixes #24)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.ha.discovery import export_discovery
+
+
+def _payload(reg: DeviceRegistry, device_id: str) -> dict:
+    dev = reg.get(device_id)
+    assert dev is not None
+    return export_discovery([dev])[0]["payload"]
+
+
+def test_energy_sensor_seed_present(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    energy = reg.get("sensor.panel_energy")
+    assert energy is not None
+    assert energy.attributes["device_class"] == "energy"
+    assert energy.attributes["unit_of_measurement"] == "kWh"
+
+
+def test_energy_sensor_uses_total_increasing(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    payload = _payload(reg, "sensor.panel_energy")
+    # Cumulative meter must be total_increasing for HA statistics / energy dash
+    assert payload["state_class"] == "total_increasing"
+    assert payload["device_class"] == "energy"
+
+
+def test_instant_sensor_stays_measurement(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    power = _payload(reg, "sensor.power_panel")
+    assert power["state_class"] == "measurement"  # instantaneous reading
+
+
+def test_air_quality_sensors_present(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    classes = {
+        d.attributes.get("device_class")
+        for d in reg.list()
+        if d.domain == "sensor"
+    }
+    assert "pm25" in classes
+    assert "carbon_dioxide" in classes
+    assert "energy" in classes


### PR DESCRIPTION
## Summary
Expands **sensor** support in HIRI-bridge with correct state classes for cumulative meters, as requested in #24.

The `sensor` discovery block hardcoded `state_class = "measurement"` for **every** sensor. That's wrong for cumulative meters: an energy meter (kWh) reports a running total, so HA needs `state_class = "total_increasing"` — otherwise long-term statistics and the Energy dashboard treat it as an instantaneous reading and the totals break. PM2.5 and CO2 seeds already existed; this PR fixes the state-class logic and adds an energy meter seed to exercise it.

## Changes
- `ha/discovery.py` — sensor block now derives `state_class`: `total_increasing` for cumulative device classes (energy/gas/water/volume/precipitation), `measurement` otherwise; still overridable via an explicit `state_class` attribute; optional `last_reset_value_template`
- `devices/registry.py` — add `sensor.panel_energy` seed (kWh, `device_class: energy`) alongside the existing instantaneous power sensor
- `tests/test_sensor_pack.py` — energy seed presence, energy → total_increasing, instantaneous power → measurement, and PM2.5/CO2/energy air-quality coverage
- `README.md` — note sensor total_increasing energy in the command-demo highlight

## Tested
```
$ pytest tests/test_sensor_pack.py -q
4 passed
$ pytest tests/ -q
20 passed, 2 skipped
```

## Acceptance
- [x] Tests pass
- [x] `hiri-bridge ha discovery` includes sensor (PM2.5 / CO2 / energy with correct state_class)
- [x] Web can show the device when bridge is running (seed devices in default registry)

## Gate 1
Both core repos starred: `mergeos-bounties/HIRI` + `mergeos-bounties/mergeos`.

Fixes #24