### PR TITLE
[25 MRG] Device pack: select scene modes (Fixes #34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Primary offline path: **bridge** (`hiri-bridge demo`).
 | **HA discovery** | Export MQTT discovery payloads offline |
 | **Adapters** | local, z2m, tuya, ha_rest, mqtt, matter (scaffold) |
 | **MQTT dry-run** | Publish discovery without a live broker |
-| **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt) in-memory |
+| **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt, select scene modes) in-memory |
 
 ---
 

--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -159,6 +159,18 @@ def default_seed_devices() -> list[Device]:
             attributes={"options": ["auto", "manual", "sleep"]},
         ),
         Device(
+            id="select.scene_living",
+            name="Living room scene",
+            domain="select",
+            model="HIRI-SCENE",
+            area="living",
+            state={"option": "day"},
+            attributes={
+                "options": ["day", "night", "movie", "party", "away"],
+            },
+            adapter="mqtt",
+        ),
+        Device(
             id="siren.alarm",
             name="Siren",
             domain="siren",
@@ -545,7 +557,7 @@ class DeviceRegistry:
             if "value" in data:
                 state["value"] = data["value"]
         elif domain == "select":
-            if "option" in data:
+            if "option" in data and data["option"] in dev.attributes.get("options", []):
                 state["option"] = data["option"]
         elif domain == "button":
             state["last_pressed"] = action or "press"

--- a/packages/bridge/src/hiri_bridge/ha/discovery.py
+++ b/packages/bridge/src/hiri_bridge/ha/discovery.py
@@ -108,6 +108,9 @@ def discovery_payload(device: Device) -> dict:
     if domain == "select":
         base["command_topic"] = command_topic(device)
         base["options"] = device.attributes.get("options", [])
+        # HA select needs a value template pointing at the reported option so
+        # the frontend reflects the active choice instead of the raw payload.
+        base["value_template"] = "{{ value_json.option }}"
     if domain == "button":
         base["command_topic"] = command_topic(device)
         base["payload_press"] = "PRESS"

--- a/packages/bridge/tests/test_select_pack.py
+++ b/packages/bridge/tests/test_select_pack.py
@@ -1,0 +1,42 @@
+"""Device pack tests: select — scene modes (Fixes #34)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.ha.discovery import export_discovery
+
+
+def test_scene_select_seed_present(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    scene = reg.get("select.scene_living")
+    assert scene is not None
+    assert scene.attributes["options"] == ["day", "night", "movie", "party", "away"]
+    assert scene.state["option"] == "day"
+
+
+def test_select_option_change_validated(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("select.scene_living", "select_option", {"option": "movie"})
+    assert dev.state["option"] == "movie"
+
+
+def test_select_rejects_invalid_option(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("select.scene_living", "select_option", {"option": "nonexistent"})
+    assert dev.state["option"] == "day"  # unchanged, invalid option ignored
+
+
+def test_select_discovery_has_value_template(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    scene = reg.get("select.scene_living")
+    assert scene is not None
+    payload = export_discovery([scene])[0]["payload"]
+
+    assert payload["options"] == ["day", "night", "movie", "party", "away"]
+    assert payload["value_template"] == "{{ value_json.option }}"


### PR DESCRIPTION
## Summary
Expands **select** support in HIRI-bridge with scene modes, as requested in #34.

The `select` discovery block emitted `options` but no `value_template`, so HA couldn't map the reported state payload to the active option. The command handler also accepted any string as a valid option with no validation. This PR fixes both and adds a scene selector seed.

## Changes
- `ha/discovery.py` — select block now emits `value_template: "{{ value_json.option }}"` so HA reflects the active choice
- `devices/registry.py` — add `select.scene_living` seed (day/night/movie/party/away scenes); `select_option` handler now validates against declared `options` before applying
- `tests/test_select_pack.py` — scene seed presence, valid option change, invalid-option rejection, discovery value_template
- `README.md` — note select scene modes in the command-demo highlight

## Tested
```
$ pytest tests/test_select_pack.py -q
4 passed
$ pytest tests/ -q
20 passed, 2 skipped
```

## Acceptance
- [x] Tests pass
- [x] `hiri-bridge ha discovery` includes select (with scene options + value_template)
- [x] Web can show the device when bridge is running (seed device in default registry)

## Gate 1
Both core repos starred: `mergeos-bounties/HIRI` + `mergeos-bounties/mergeos`.

Fixes #34