### PR TITLE
[25 MRG] Device pack: number unit + min/max clamping (Fixes #33)

### DIFF
--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -657,7 +657,9 @@ class DeviceRegistry:
                     state["preset_mode"] = data["preset_mode"]
         elif domain == "number":
             if "value" in data:
-                state["value"] = data["value"]
+                lo = dev.attributes.get("min", 0)
+                hi = dev.attributes.get("max", 100)
+                state["value"] = max(lo, min(hi, data["value"]))
         elif domain == "select":
             if "option" in data and data["option"] in dev.attributes.get("options", []):
                 state["option"] = data["option"]

--- a/packages/bridge/src/hiri_bridge/ha/discovery.py
+++ b/packages/bridge/src/hiri_bridge/ha/discovery.py
@@ -148,6 +148,14 @@ def discovery_payload(device: Device) -> dict:
         base["min"] = device.attributes.get("min", 0)
         base["max"] = device.attributes.get("max", 100)
         base["step"] = device.attributes.get("step", 1)
+        # Surface the configured unit + entry mode so HA renders the number
+        # with its unit label and the right control (slider vs box).
+        unit = device.attributes.get("unit")
+        if unit:
+            base["unit_of_measurement"] = unit
+        base["mode"] = device.attributes.get("mode", "auto")
+        if "device_class" in device.attributes:
+            base["device_class"] = device.attributes["device_class"]
     if domain == "select":
         base["command_topic"] = command_topic(device)
         base["options"] = device.attributes.get("options", [])

--- a/packages/bridge/tests/test_number_pack.py
+++ b/packages/bridge/tests/test_number_pack.py
@@ -1,0 +1,43 @@
+"""Device pack tests: number — calibration min/max (Fixes #33)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.ha.discovery import export_discovery
+
+
+def test_number_emits_unit_and_mode(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dose = reg.get("number.feed_dose")
+    assert dose is not None
+    payload = export_discovery([dose])[0]["payload"]
+
+    assert payload["unit_of_measurement"] == "ml"
+    assert payload["min"] == 0
+    assert payload["max"] == 500
+    assert payload["step"] == 10
+    assert payload["mode"] == "auto"
+
+
+def test_number_value_clamped_to_max(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("number.feed_dose", "set_value", {"value": 9999})
+    assert dev.state["value"] == 500  # clamped to max
+
+
+def test_number_value_clamped_to_min(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("number.feed_dose", "set_value", {"value": -50})
+    assert dev.state["value"] == 0  # clamped to min
+
+
+def test_number_value_within_range_kept(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("number.feed_dose", "set_value", {"value": 120})
+    assert dev.state["value"] == 120


### PR DESCRIPTION
## Summary
Expands **number** support in HIRI-bridge with unit/mode discovery and value clamping, as requested in #33.

Two gaps: (1) the number seed declared a `unit` attribute but the discovery block never emitted `unit_of_measurement` or `mode`, so HA rendered the entity with no unit label and a default control; (2) the command handler stored the raw value with no bounds check, so out-of-range values (e.g. 9999 on a 0-500 dose) were accepted. This PR fixes both.

## Changes
- `ha/discovery.py` — number block now emits `unit_of_measurement` (when declared), `mode` (auto/slider/box), and optional `device_class`
- `devices/registry.py` — `set_value` now clamps to the device's declared `min`/`max` before storing
- `tests/test_number_pack.py` — unit/mode discovery, clamp-to-max, clamp-to-min, and in-range passthrough
- `README.md` — note number min/max clamping in the command-demo highlight

## Tested
```
$ pytest tests/test_number_pack.py -q
4 passed
$ pytest tests/ -q
20 passed, 2 skipped
```

## Acceptance
- [x] Tests pass
- [x] `hiri-bridge ha discovery` includes number (with unit + mode)
- [x] Web can show the device when bridge is running (seed device in default registry)

## Gate 1
Both core repos starred: `mergeos-bounties/HIRI` + `mergeos-bounties/mergeos`.

Fixes #33