### PR TITLE
[25 MRG] Device pack: media_player source list (Fixes #29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Primary offline path: **bridge** (`hiri-bridge demo`).
 | **HA discovery** | Export MQTT discovery payloads offline |
 | **Adapters** | local, z2m, tuya, ha_rest, mqtt, matter (scaffold) |
 | **MQTT dry-run** | Publish discovery without a live broker |
-| **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt, select scene modes) in-memory |
+| **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt, select scene modes, number min/max clamping, media_player source list) in-memory |
 
 ---
 

--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -132,7 +132,10 @@ def default_seed_devices() -> list[Device]:
             domain="media_player",
             model="HIRI-TV",
             area="living",
-            state={"state": "off", "volume_level": 0.2},
+            state={"state": "off", "volume_level": 0.2, "source": "HDMI 1"},
+            attributes={
+                "source_list": ["HDMI 1", "HDMI 2", "Netflix", "YouTube", "TV"],
+            },
         ),
         Device(
             id="vacuum.bot_1",
@@ -595,6 +598,8 @@ class DeviceRegistry:
                 state["state"] = "off" if action == "turn_off" else "playing" if action == "play" else "idle"
             if "volume_level" in data:
                 state["volume_level"] = data["volume_level"]
+            if "source" in data and data["source"] in dev.attributes.get("source_list", []):
+                state["source"] = data["source"]
         else:
             state["last_action"] = action
             state.update(data)

--- a/packages/bridge/src/hiri_bridge/ha/discovery.py
+++ b/packages/bridge/src/hiri_bridge/ha/discovery.py
@@ -122,6 +122,16 @@ def discovery_payload(device: Device) -> dict:
         base["supported_features"] = ["start", "return_home", "battery"]
     if domain == "media_player":
         base["command_topic"] = command_topic(device)
+        # Expose selectable inputs + volume/source support so HA renders the
+        # source dropdown and the right transport controls.
+        source_list = device.attributes.get("source_list")
+        if source_list:
+            base["source_list"] = source_list
+            base["source_command_topic"] = command_topic(device) + "/source"
+        base["supported_features"] = device.attributes.get(
+            "supported_features",
+            ["turn_on", "turn_off", "play", "pause", "volume_set"],
+        )
     if domain == "alarm_control_panel":
         base["command_topic"] = command_topic(device)
         base["supported_features"] = ["arm_home", "arm_away", "trigger"]

--- a/packages/bridge/tests/test_media_player_pack.py
+++ b/packages/bridge/tests/test_media_player_pack.py
@@ -1,0 +1,43 @@
+"""Device pack tests: media_player — source list (Fixes #29)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.ha.discovery import export_discovery
+
+
+def test_tv_source_list_seed_present(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    tv = reg.get("media_player.tv_living")
+    assert tv is not None
+    assert tv.attributes["source_list"] == ["HDMI 1", "HDMI 2", "Netflix", "YouTube", "TV"]
+    assert tv.state["source"] == "HDMI 1"
+
+
+def test_media_player_discovery_emits_source_list(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    tv = reg.get("media_player.tv_living")
+    assert tv is not None
+    payload = export_discovery([tv])[0]["payload"]
+
+    assert payload["source_list"] == ["HDMI 1", "HDMI 2", "Netflix", "YouTube", "TV"]
+    assert "source_command_topic" in payload
+    assert "volume_set" in payload["supported_features"]
+
+
+def test_select_source_validated(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("media_player.tv_living", "select_source", {"source": "Netflix"})
+    assert dev.state["source"] == "Netflix"
+
+
+def test_select_source_rejects_invalid(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("media_player.tv_living", "select_source", {"source": "Nonexistent"})
+    assert dev.state["source"] == "HDMI 1"  # unchanged


### PR DESCRIPTION
## Summary
Expands **media_player** support in HIRI-bridge with a selectable source list, as requested in #29.

The `media_player` discovery block only emitted a `command_topic` — no `source_list`, no `supported_features`, so HA couldn't render the input/source dropdown or the transport controls. The command handler also had no way to switch source. This PR wires source selection through end to end.

## Changes
- `ha/discovery.py` — media_player block now emits `source_list` + `source_command_topic` (when declared) and `supported_features` (turn_on/off, play, pause, volume_set)
- `devices/registry.py` — enrich the `media_player.tv_living` seed with a source list (HDMI 1/2, Netflix, YouTube, TV) + current source; `select_source` handler validates against the declared list
- `tests/test_media_player_pack.py` — source seed presence, discovery source_list emission, valid source switch, invalid-source rejection
- `README.md` — note media_player source list in the command-demo highlight

## Tested
```
$ pytest tests/test_media_player_pack.py -q
4 passed
$ pytest tests/ -q
27 passed, 2 skipped
```

## Acceptance
- [x] Tests pass
- [x] `hiri-bridge ha discovery` includes media_player (with source_list)
- [x] Web can show the device when bridge is running (seed device in default registry)

## Gate 1
Both core repos starred: `mergeos-bounties/HIRI` + `mergeos-bounties/mergeos`.

Fixes #29