### PR TITLE
[25 MRG] Device pack: vacuum room map + fan speed (Fixes #30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Primary offline path: **bridge** (`hiri-bridge demo`).
 | **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt, select scene modes, number min/max clamping, media_player source list, water_heater away mode, alarm arm modes) in-memory |
 | **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt, select scene modes, number min/max clamping, media_player source list, button multi-press, alarm arm modes) in-memory |
 | **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt, select scene modes, number min/max clamping, media_player source list, camera snapshot URL, alarm arm modes) in-memory |
+| **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt, select scene modes, number min/max clamping, media_player source list, vacuum room map, alarm arm modes) in-memory |
 
 ---
 

--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -183,7 +183,11 @@ def default_seed_devices() -> list[Device]:
             domain="vacuum",
             model="HIRI-VAC",
             area="home",
-            state={"state": "docked", "battery": 100},
+            state={"state": "docked", "battery": 100, "fan_speed": "balanced"},
+            attributes={
+                "fan_speed_list": ["quiet", "balanced", "turbo", "max"],
+                "rooms": ["living", "kitchen", "bedroom", "hallway"],
+            },
         ),
         Device(
             id="camera.yard",
@@ -705,6 +709,11 @@ class DeviceRegistry:
         elif domain == "vacuum":
             if action in {"start", "return_to_base", "dock"}:
                 state["state"] = "cleaning" if action == "start" else "docked"
+            if "fan_speed" in data and data["fan_speed"] in dev.attributes.get("fan_speed_list", []):
+                state["fan_speed"] = data["fan_speed"]
+            if action == "clean_room" and data.get("room") in dev.attributes.get("rooms", []):
+                state["state"] = "cleaning"
+                state["current_room"] = data["room"]
         elif domain == "alarm_control_panel":
             arm_map = {
                 "arm_home": "armed_home",

--- a/packages/bridge/src/hiri_bridge/ha/discovery.py
+++ b/packages/bridge/src/hiri_bridge/ha/discovery.py
@@ -196,7 +196,18 @@ def discovery_payload(device: Device) -> dict:
             base["still_image_url"] = snapshot_url
     if domain == "vacuum":
         base["command_topic"] = command_topic(device)
-        base["supported_features"] = ["start", "return_home", "battery"]
+        base["supported_features"] = device.attributes.get(
+            "supported_features",
+            ["start", "return_home", "battery", "fan_speed"],
+        )
+        # Expose fan speed presets + mapped rooms so HA can offer targeted
+        # segment cleaning instead of whole-home only.
+        fan_speed_list = device.attributes.get("fan_speed_list")
+        if fan_speed_list:
+            base["fan_speed_list"] = fan_speed_list
+        rooms = device.attributes.get("rooms")
+        if rooms:
+            base["json_attributes_topic"] = state_topic(device) + "/attributes"
     if domain == "media_player":
         base["command_topic"] = command_topic(device)
         # Expose selectable inputs + volume/source support so HA renders the

--- a/packages/bridge/tests/test_vacuum_pack.py
+++ b/packages/bridge/tests/test_vacuum_pack.py
@@ -1,0 +1,59 @@
+"""Device pack tests: vacuum — room map + fan speed (Fixes #30)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.ha.discovery import export_discovery
+
+
+def test_vacuum_seed_has_rooms_and_fan_speed(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    bot = reg.get("vacuum.bot_1")
+    assert bot is not None
+    assert bot.attributes["rooms"] == ["living", "kitchen", "bedroom", "hallway"]
+    assert bot.attributes["fan_speed_list"] == ["quiet", "balanced", "turbo", "max"]
+
+
+def test_vacuum_discovery_emits_fan_speed_list(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    bot = reg.get("vacuum.bot_1")
+    assert bot is not None
+    payload = export_discovery([bot])[0]["payload"]
+
+    assert payload["fan_speed_list"] == ["quiet", "balanced", "turbo", "max"]
+    assert "fan_speed" in payload["supported_features"]
+    assert "json_attributes_topic" in payload
+
+
+def test_vacuum_set_fan_speed_validated(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("vacuum.bot_1", "set_fan_speed", {"fan_speed": "turbo"})
+    assert dev.state["fan_speed"] == "turbo"
+
+
+def test_vacuum_set_fan_speed_rejects_invalid(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("vacuum.bot_1", "set_fan_speed", {"fan_speed": "warp9"})
+    assert dev.state["fan_speed"] == "balanced"  # unchanged
+
+
+def test_vacuum_clean_room(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("vacuum.bot_1", "clean_room", {"room": "kitchen"})
+    assert dev.state["state"] == "cleaning"
+    assert dev.state["current_room"] == "kitchen"
+
+
+def test_vacuum_clean_room_rejects_unknown(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("vacuum.bot_1", "clean_room", {"room": "garage"})
+    assert dev.state["state"] == "docked"  # unchanged
+    assert "current_room" not in dev.state


### PR DESCRIPTION
## Summary
Expands **vacuum** support in HIRI-bridge with fan-speed presets and mapped-room targeted cleaning, as requested in #30.

The vacuum discovery block emitted a static `supported_features` list and nothing else — no `fan_speed_list`, no room map, so HA could only start/dock the whole home. The command handler had no way to set fan speed or clean a specific room. This PR wires both through end to end.

## Changes
- `ha/discovery.py` — vacuum block now emits `fan_speed_list` (when declared), `json_attributes_topic` for mapped rooms, and `fan_speed` in `supported_features`
- `devices/registry.py` — enrich the `vacuum.bot_1` seed with a fan-speed list (quiet/balanced/turbo/max) + rooms (living/kitchen/bedroom/hallway); `set_fan_speed` validates against the list, `clean_room` validates against the mapped rooms
- `tests/test_vacuum_pack.py` — seed presence, discovery emission, fan-speed valid/invalid, clean_room valid/unknown
- `README.md` — note vacuum room map in the command-demo highlight

## Tested
```
$ pytest tests/test_vacuum_pack.py -q
6 passed
$ pytest tests/ -q
29 passed, 2 skipped
```

## Acceptance
- [x] Tests pass
- [x] `hiri-bridge ha discovery` includes vacuum (with fan_speed_list)
- [x] Web can show the device when bridge is running (seed device in default registry)

## Gate 1
Both core repos starred: `mergeos-bounties/HIRI` + `mergeos-bounties/mergeos`.

Fixes #30