### PR TITLE
[25 MRG] Device pack: camera snapshot + stream URL (Fixes #31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Primary offline path: **bridge** (`hiri-bridge demo`).
 | **MQTT dry-run** | Publish discovery without a live broker |
 | **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt, select scene modes, number min/max clamping, media_player source list, water_heater away mode, alarm arm modes) in-memory |
 | **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt, select scene modes, number min/max clamping, media_player source list, button multi-press, alarm arm modes) in-memory |
+| **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt, select scene modes, number min/max clamping, media_player source list, camera snapshot URL, alarm arm modes) in-memory |
 
 ---
 

--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -192,7 +192,10 @@ def default_seed_devices() -> list[Device]:
             model="HIRI-CAM",
             area="yard",
             state={"state": "idle"},
-            attributes={"stream_url": "rtsp://192.0.2.10/stream"},
+            attributes={
+                "stream_url": "rtsp://192.0.2.10/stream",
+                "snapshot_url": "http://192.0.2.10/snapshot.jpg",
+            },
         ),
         Device(
             id="button.panic",

--- a/packages/bridge/src/hiri_bridge/ha/discovery.py
+++ b/packages/bridge/src/hiri_bridge/ha/discovery.py
@@ -186,6 +186,14 @@ def discovery_payload(device: Device) -> dict:
             base["event_topic"] = state_topic(device) + "/event"
     if domain == "camera":
         base["topic"] = state_topic(device)
+        # Surface the RTSP/stream source and a still-image snapshot URL so HA
+        # can render a live feed + thumbnails instead of a bare topic.
+        stream_url = device.attributes.get("stream_url")
+        if stream_url:
+            base["stream_source"] = stream_url
+        snapshot_url = device.attributes.get("snapshot_url")
+        if snapshot_url:
+            base["still_image_url"] = snapshot_url
     if domain == "vacuum":
         base["command_topic"] = command_topic(device)
         base["supported_features"] = ["start", "return_home", "battery"]

--- a/packages/bridge/tests/test_camera_pack.py
+++ b/packages/bridge/tests/test_camera_pack.py
@@ -1,0 +1,40 @@
+"""Device pack tests: camera — snapshot URL (Fixes #31)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.ha.discovery import export_discovery
+
+
+def test_camera_seed_has_snapshot_url(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    cam = reg.get("camera.yard")
+    assert cam is not None
+    assert cam.attributes["snapshot_url"] == "http://192.0.2.10/snapshot.jpg"
+    assert cam.attributes["stream_url"] == "rtsp://192.0.2.10/stream"
+
+
+def test_camera_discovery_emits_snapshot_and_stream(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    cam = reg.get("camera.yard")
+    assert cam is not None
+    payload = export_discovery([cam])[0]["payload"]
+
+    assert payload["still_image_url"] == "http://192.0.2.10/snapshot.jpg"
+    assert payload["stream_source"] == "rtsp://192.0.2.10/stream"
+
+
+def test_camera_discovery_omits_snapshot_when_absent(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    cam = reg.get("camera.yard")
+    assert cam is not None
+    cam.attributes.pop("snapshot_url", None)
+    payload = export_discovery([cam])[0]["payload"]
+
+    assert "still_image_url" not in payload
+    assert payload["stream_source"] == "rtsp://192.0.2.10/stream"


### PR DESCRIPTION
## Summary
Expands **camera** support in HIRI-bridge by surfacing the stream source and a still-image snapshot URL, as requested in #31.

The camera seed already carried a `stream_url` attribute, but the discovery block only emitted `topic` — the stream URL was never exposed, and there was no snapshot URL at all. HA needs `stream_source` for the live feed and `still_image_url` for thumbnails. This PR emits both when declared.

## Changes
- `ha/discovery.py` — camera block now emits `stream_source` (from `stream_url`) and `still_image_url` (from `snapshot_url`) when present
- `devices/registry.py` — enrich the `camera.yard` seed with a `snapshot_url` alongside the existing `stream_url`
- `tests/test_camera_pack.py` — seed presence, discovery emission of both URLs, graceful omission when snapshot absent
- `README.md` — note camera snapshot URL in the command-demo highlight

## Tested
```
$ pytest tests/test_camera_pack.py -q
3 passed
$ pytest tests/ -q
26 passed, 2 skipped
```

## Acceptance
- [x] Tests pass
- [x] `hiri-bridge ha discovery` includes camera (with still_image_url + stream_source)
- [x] Web can show the device when bridge is running (seed device in default registry)

## Gate 1
Both core repos starred: `mergeos-bounties/HIRI` + `mergeos-bounties/mergeos`.

Fixes #31