### PR TITLE
[25 MRG] Device pack: button single/double/long press (Fixes #32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Primary offline path: **bridge** (`hiri-bridge demo`).
 | **Adapters** | local, z2m, tuya, ha_rest, mqtt, matter (scaffold) |
 | **MQTT dry-run** | Publish discovery without a live broker |
 | **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt, select scene modes, number min/max clamping, media_player source list, water_heater away mode, alarm arm modes) in-memory |
+| **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt, select scene modes, number min/max clamping, media_player source list, button multi-press, alarm arm modes) in-memory |
 
 ---
 

--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -201,6 +201,9 @@ def default_seed_devices() -> list[Device]:
             model="HIRI-BTN",
             area="entry",
             state={},
+            attributes={
+                "event_types": ["single", "double", "long"],
+            },
         ),
         Device(
             id="number.feed_dose",
@@ -691,7 +694,11 @@ class DeviceRegistry:
             if "option" in data and data["option"] in dev.attributes.get("options", []):
                 state["option"] = data["option"]
         elif domain == "button":
-            state["last_pressed"] = action or "press"
+            press_type = data.get("press_type", "single")
+            if press_type in dev.attributes.get("event_types", ["single"]):
+                state["last_pressed"] = press_type
+            else:
+                state["last_pressed"] = "single"
         elif domain == "vacuum":
             if action in {"start", "return_to_base", "dock"}:
                 state["state"] = "cleaning" if action == "start" else "docked"

--- a/packages/bridge/src/hiri_bridge/ha/discovery.py
+++ b/packages/bridge/src/hiri_bridge/ha/discovery.py
@@ -178,6 +178,12 @@ def discovery_payload(device: Device) -> dict:
     if domain == "button":
         base["command_topic"] = command_topic(device)
         base["payload_press"] = "PRESS"
+        # Expose multi-press event types so HA can bind device automations to
+        # single / double / long presses instead of a single fire-and-forget.
+        event_types = device.attributes.get("event_types")
+        if event_types:
+            base["event_types"] = event_types
+            base["event_topic"] = state_topic(device) + "/event"
     if domain == "camera":
         base["topic"] = state_topic(device)
     if domain == "vacuum":

--- a/packages/bridge/tests/test_button_pack.py
+++ b/packages/bridge/tests/test_button_pack.py
@@ -1,0 +1,48 @@
+"""Device pack tests: button — single/double/long press (Fixes #32)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.ha.discovery import export_discovery
+
+
+def test_button_seed_has_event_types(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    btn = reg.get("button.panic")
+    assert btn is not None
+    assert btn.attributes["event_types"] == ["single", "double", "long"]
+
+
+def test_button_discovery_emits_event_types(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    btn = reg.get("button.panic")
+    assert btn is not None
+    payload = export_discovery([btn])[0]["payload"]
+
+    assert payload["event_types"] == ["single", "double", "long"]
+    assert "event_topic" in payload
+
+
+def test_button_double_press_recorded(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("button.panic", "press", {"press_type": "double"})
+    assert dev.state["last_pressed"] == "double"
+
+
+def test_button_long_press_recorded(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("button.panic", "press", {"press_type": "long"})
+    assert dev.state["last_pressed"] == "long"
+
+
+def test_button_invalid_press_falls_back_to_single(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("button.panic", "press", {"press_type": "triple"})
+    assert dev.state["last_pressed"] == "single"


### PR DESCRIPTION
## Summary
Expands **button** support in HIRI-bridge with single/double/long press event types, as requested in #32.

The button block only emitted a single `payload_press` — no multi-press support, so HA could only bind a fire-and-forget action, not distinguish single vs double vs long press for device automations. This PR emits `event_types` + an event topic and records the press type in state.

## Changes
- `ha/discovery.py` — button block now emits `event_types` + `event_topic` (when declared) so HA can bind device automations per press type
- `devices/registry.py` — enrich the `button.panic` seed with event types (single/double/long); the press handler validates `press_type` against the declared list and falls back to `single` for unknown types
- `tests/test_button_pack.py` — seed presence, discovery emission, double/long press recorded, invalid press falls back to single
- `README.md` — note button multi-press in the command-demo highlight

## Tested
```
$ pytest tests/test_button_pack.py -q
5 passed
$ pytest tests/ -q
32 passed, 2 skipped
```

## Acceptance
- [x] Tests pass
- [x] `hiri-bridge ha discovery` includes button (with event_types)
- [x] Web can show the device when bridge is running (seed device in default registry)

## Gate 1
Both core repos starred: `mergeos-bounties/HIRI` + `mergeos-bounties/mergeos`.

Fixes #32