### PR TITLE
[25 MRG] Device pack: water_heater away mode (Fixes #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Primary offline path: **bridge** (`hiri-bridge demo`).
 | **HA discovery** | Export MQTT discovery payloads offline |
 | **Adapters** | local, z2m, tuya, ha_rest, mqtt, matter (scaffold) |
 | **MQTT dry-run** | Publish discovery without a live broker |
-| **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt, select scene modes, number min/max clamping, media_player source list, alarm arm modes) in-memory |
+| **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt, select scene modes, number min/max clamping, media_player source list, water_heater away mode, alarm arm modes) in-memory |
 
 ---
 

--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -246,7 +246,12 @@ def default_seed_devices() -> list[Device]:
             domain="water_heater",
             model="HIRI-WH",
             area="utility",
-            state={"state": "off", "temperature": 45},
+            state={"state": "off", "temperature": 45, "mode": "eco"},
+            attributes={
+                "modes": ["off", "eco", "performance", "away"],
+                "min_temp": 30,
+                "max_temp": 70,
+            },
         ),
         Device(
             id="alarm_control_panel.home",
@@ -564,7 +569,7 @@ class DeviceRegistry:
         data = data or {}
         state = dict(dev.state)
         domain = dev.domain
-        if domain in {"light", "switch", "fan", "siren", "humidifier", "water_heater"}:
+        if domain in {"light", "switch", "fan", "siren", "humidifier"}:
             if action in {"turn_on", "on"}:
                 state["state"] = "on"
                 if "brightness" in data:
@@ -678,6 +683,14 @@ class DeviceRegistry:
                 state["volume_level"] = data["volume_level"]
             if "source" in data and data["source"] in dev.attributes.get("source_list", []):
                 state["source"] = data["source"]
+        elif domain == "water_heater":
+            if "mode" in data and data["mode"] in dev.attributes.get("modes", []):
+                state["mode"] = data["mode"]
+                state["state"] = "off" if data["mode"] == "off" else "on"
+            if "temperature" in data:
+                lo = dev.attributes.get("min_temp", 30)
+                hi = dev.attributes.get("max_temp", 70)
+                state["temperature"] = max(lo, min(hi, data["temperature"]))
         else:
             state["last_action"] = action
             state.update(data)

--- a/packages/bridge/src/hiri_bridge/ha/discovery.py
+++ b/packages/bridge/src/hiri_bridge/ha/discovery.py
@@ -179,6 +179,15 @@ def discovery_payload(device: Device) -> dict:
     if domain == "water_heater":
         base["command_topic"] = command_topic(device)
         base["temperature_unit"] = "C"
+        base["min_temp"] = device.attributes.get("min_temp", 30)
+        base["max_temp"] = device.attributes.get("max_temp", 70)
+        # Expose operation modes (incl. eco/away) + a dedicated mode topic so
+        # HA can toggle away mode instead of only setting a target temperature.
+        modes = device.attributes.get("modes")
+        if modes:
+            base["modes"] = modes
+            base["mode_command_topic"] = command_topic(device) + "/mode"
+            base["mode_state_topic"] = state_topic(device) + "/mode"
     return base
 
 

--- a/packages/bridge/tests/test_water_heater_pack.py
+++ b/packages/bridge/tests/test_water_heater_pack.py
@@ -1,0 +1,61 @@
+"""Device pack tests: water_heater — away mode + temp clamping (Fixes #37)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.ha.discovery import export_discovery
+
+
+def test_boiler_seed_has_modes(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    boiler = reg.get("water_heater.boiler")
+    assert boiler is not None
+    assert boiler.attributes["modes"] == ["off", "eco", "performance", "away"]
+    assert boiler.state["mode"] == "eco"
+
+
+def test_water_heater_discovery_emits_modes(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    boiler = reg.get("water_heater.boiler")
+    assert boiler is not None
+    payload = export_discovery([boiler])[0]["payload"]
+
+    assert payload["modes"] == ["off", "eco", "performance", "away"]
+    assert payload["min_temp"] == 30
+    assert payload["max_temp"] == 70
+    assert "mode_command_topic" in payload
+
+
+def test_water_heater_set_away_mode(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("water_heater.boiler", "set_mode", {"mode": "away"})
+    assert dev.state["mode"] == "away"
+    assert dev.state["state"] == "on"
+
+
+def test_water_heater_off_mode_sets_state_off(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("water_heater.boiler", "set_mode", {"mode": "off"})
+    assert dev.state["state"] == "off"
+
+
+def test_water_heater_temperature_clamped(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("water_heater.boiler", "set_temperature", {"temperature": 999})
+    assert dev.state["temperature"] == 70
+    dev = reg.apply_command("water_heater.boiler", "set_temperature", {"temperature": -5})
+    assert dev.state["temperature"] == 30
+
+
+def test_water_heater_invalid_mode_ignored(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("water_heater.boiler", "set_mode", {"mode": "turbo"})
+    assert dev.state["mode"] == "eco"  # unchanged


### PR DESCRIPTION
## Summary
Expands **water_heater** support in HIRI-bridge with operation modes (incl. away mode) and temperature clamping, as requested in #37.

Two bugs here:
1. The discovery block only emitted `command_topic` + `temperature_unit` — no `modes`, no min/max temp, so HA had no way to switch to away mode.
2. `water_heater` was grouped into the generic `{light, switch, fan, siren, humidifier}` on/off handler in `apply_command`, so a dedicated water_heater command branch would never execute (it always matched the generic `if` first). Any `set_mode`/`set_temperature` command was silently swallowed.

## Changes
- `ha/discovery.py` — water_heater block now emits `min_temp`/`max_temp` and `modes` + `mode_command_topic`/`mode_state_topic` (when declared)
- `devices/registry.py` — removed `water_heater` from the generic on/off domain set (root cause of the swallowed commands); added a dedicated water_heater branch validating `mode` against the declared list and clamping `temperature` to `[min_temp, max_temp]`; enriched the `water_heater.boiler` seed with `modes: [off, eco, performance, away]` + temp bounds
- `tests/test_water_heater_pack.py` — seed presence, discovery emission, away-mode set, off-mode state sync, temperature clamping (both bounds), invalid mode rejected
- `README.md` — note water_heater away mode in the command-demo highlight

## Tested
```
$ pytest tests/test_water_heater_pack.py -q
6 passed
$ pytest tests/ -q
41 passed, 2 skipped
```

## Acceptance
- [x] Tests pass
- [x] `hiri-bridge ha discovery` includes water_heater (with modes)
- [x] Web can show the device when bridge is running (seed device in default registry)

## Gate 1
Both core repos starred: `mergeos-bounties/HIRI` + `mergeos-bounties/mergeos`.

Fixes #37