### PR TITLE
[25 MRG] Device pack: alarm_control_panel arm modes (Fixes #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Primary offline path: **bridge** (`hiri-bridge demo`).
 | **HA discovery** | Export MQTT discovery payloads offline |
 | **Adapters** | local, z2m, tuya, ha_rest, mqtt, matter (scaffold) |
 | **MQTT dry-run** | Publish discovery without a live broker |
-| **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt, select scene modes, number min/max clamping, media_player source list) in-memory |
+| **Command demo** | Apply sample commands (brightness, effects, fan presets, climate thermostat presets, cover tilt, select scene modes, number min/max clamping, media_player source list, alarm arm modes) in-memory |
 
 ---
 

--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -255,6 +255,11 @@ def default_seed_devices() -> list[Device]:
             model="HIRI-ALARM",
             area="home",
             state={"state": "disarmed"},
+            attributes={
+                "code_arm_required": True,
+                "code_disarm_required": True,
+                "code": "1234",
+            },
         ),
         Device(
             id="binary_sensor.window_kitchen",
@@ -647,12 +652,25 @@ class DeviceRegistry:
             if action in {"start", "return_to_base", "dock"}:
                 state["state"] = "cleaning" if action == "start" else "docked"
         elif domain == "alarm_control_panel":
-            if action in {"arm_home", "arm_away", "disarm"}:
-                state["state"] = {
-                    "arm_home": "armed_home",
-                    "arm_away": "armed_away",
-                    "disarm": "disarmed",
-                }[action]
+            arm_map = {
+                "arm_home": "armed_home",
+                "arm_away": "armed_away",
+                "arm_night": "armed_night",
+                "arm_vacation": "armed_vacation",
+                "disarm": "disarmed",
+                "trigger": "triggered",
+            }
+            if action in arm_map:
+                required = dev.attributes.get(
+                    "code_disarm_required" if action == "disarm" else "code_arm_required",
+                    False,
+                )
+                expected = dev.attributes.get("code")
+                if required and action != "trigger" and data.get("code") != expected:
+                    state["last_error"] = "invalid_code"
+                else:
+                    state["state"] = arm_map[action]
+                    state.pop("last_error", None)
         elif domain == "media_player":
             if action in {"turn_on", "turn_off", "play", "pause"}:
                 state["state"] = "off" if action == "turn_off" else "playing" if action == "play" else "idle"

--- a/packages/bridge/src/hiri_bridge/ha/discovery.py
+++ b/packages/bridge/src/hiri_bridge/ha/discovery.py
@@ -168,7 +168,14 @@ def discovery_payload(device: Device) -> dict:
         )
     if domain == "alarm_control_panel":
         base["command_topic"] = command_topic(device)
-        base["supported_features"] = ["arm_home", "arm_away", "trigger"]
+        base["supported_features"] = device.attributes.get(
+            "supported_features",
+            ["arm_home", "arm_away", "arm_night", "arm_vacation", "trigger"],
+        )
+        # Advertise whether a code is required to arm/disarm so HA renders the
+        # keypad instead of bare arm buttons.
+        base["code_arm_required"] = device.attributes.get("code_arm_required", False)
+        base["code_disarm_required"] = device.attributes.get("code_disarm_required", False)
     if domain == "water_heater":
         base["command_topic"] = command_topic(device)
         base["temperature_unit"] = "C"

--- a/packages/bridge/tests/test_alarm_pack.py
+++ b/packages/bridge/tests/test_alarm_pack.py
@@ -1,0 +1,68 @@
+"""Device pack tests: alarm_control_panel — arm modes + code (Fixes #38)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.ha.discovery import export_discovery
+
+
+def test_alarm_seed_requires_code(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    alarm = reg.get("alarm_control_panel.home")
+    assert alarm is not None
+    assert alarm.attributes["code_arm_required"] is True
+    assert alarm.attributes["code_disarm_required"] is True
+
+
+def test_alarm_discovery_emits_arm_modes(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    alarm = reg.get("alarm_control_panel.home")
+    assert alarm is not None
+    payload = export_discovery([alarm])[0]["payload"]
+
+    assert "arm_night" in payload["supported_features"]
+    assert "arm_vacation" in payload["supported_features"]
+    assert payload["code_arm_required"] is True
+    assert payload["code_disarm_required"] is True
+
+
+def test_alarm_arm_night_with_code(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("alarm_control_panel.home", "arm_night", {"code": "1234"})
+    assert dev.state["state"] == "armed_night"
+
+
+def test_alarm_arm_vacation_with_code(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("alarm_control_panel.home", "arm_vacation", {"code": "1234"})
+    assert dev.state["state"] == "armed_vacation"
+
+
+def test_alarm_arm_rejected_without_code(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("alarm_control_panel.home", "arm_away", {"code": "0000"})
+    assert dev.state["state"] == "disarmed"  # unchanged
+    assert dev.state["last_error"] == "invalid_code"
+
+
+def test_alarm_disarm_with_code_clears_error(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    reg.apply_command("alarm_control_panel.home", "arm_away", {"code": "0000"})  # sets error
+    dev = reg.apply_command("alarm_control_panel.home", "disarm", {"code": "1234"})
+    assert dev.state["state"] == "disarmed"
+    assert "last_error" not in dev.state
+
+
+def test_alarm_trigger_bypasses_code(tmp_path: Path) -> None:
+    reg = DeviceRegistry(path=tmp_path / "devices.json")
+    reg.seed()
+    dev = reg.apply_command("alarm_control_panel.home", "trigger", {})
+    assert dev.state["state"] == "triggered"


### PR DESCRIPTION
## Summary
Expands **alarm_control_panel** support in HIRI-bridge with night/vacation arm modes and code enforcement, as requested in #38.

The alarm block only supported `arm_home`/`arm_away`/`trigger` — no night or vacation mode, and no code requirement at all (any client could arm/disarm silently). This PR adds both.

## Changes
- `ha/discovery.py` — alarm block now emits `arm_night`/`arm_vacation` in `supported_features` and advertises `code_arm_required`/`code_disarm_required`
- `devices/registry.py` — `alarm_control_panel.home` seed now requires a code to arm/disarm; the command handler validates `code` against the stored value for every arm/disarm action (trigger bypasses code, matching real alarm panels), sets `last_error: invalid_code` on mismatch and clears it on success
- `tests/test_alarm_pack.py` — seed presence, discovery emission, night/vacation arm with valid code, arm rejected without correct code, disarm clears error, trigger bypasses code
- `README.md` — note alarm arm modes in the command-demo highlight

## Tested
```
$ pytest tests/test_alarm_pack.py -q
7 passed
$ pytest tests/ -q
50 passed, 2 skipped
```

## Acceptance
- [x] Tests pass
- [x] `hiri-bridge ha discovery` includes alarm_control_panel (with arm_night/arm_vacation)
- [x] Web can show the device when bridge is running (seed device in default registry)

## Gate 1
Both core repos starred: `mergeos-bounties/HIRI` + `mergeos-bounties/mergeos`.

Fixes #38