### PR TITLE
Fixes #77: Device pack: lock.front_door (append-only)

### DIFF
--- a/devices/lock_front_door.json
+++ b/devices/lock_front_door.json
@@ -1,0 +1,7 @@
+{
+  "device_id": "lock.front_door",
+  "type": "smart_lock",
+  "policy": "append-only",
+  "description": "Front door main lock. Audit logs and state changes are append-only.",
+  "status": "active"
+}


### PR DESCRIPTION
Closes #77. Added the append-only device configuration file for the front door smart lock.