### PR TITLE
feat(bridge): add irrigation zone switch

### DIFF
--- a/packages/bridge/data/devices.json
+++ b/packages/bridge/data/devices.json
@@ -1860,5 +1860,19 @@
       "state_class": "measurement"
     },
     "adapter": "mqtt"
+  },
+  {
+    "id": "switch.irrigation_zone_a",
+    "name": "Irrigation zone A",
+    "domain": "switch",
+    "manufacturer": "HIRI",
+    "model": "HIRI-RELAY",
+    "area": "farm",
+    "online": true,
+    "state": {
+      "state": "off"
+    },
+    "attributes": {},
+    "adapter": "mqtt"
   }
 ]

--- a/packages/bridge/tests/test_switch_pack.py
+++ b/packages/bridge/tests/test_switch_pack.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+from hiri_bridge.config import package_root
 from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.devices.types import Device
 from hiri_bridge.ha.discovery import export_discovery
+
+
+def _device_pack() -> dict[str, dict]:
+    raw = (package_root() / "data" / "devices.json").read_text(encoding="utf-8")
+    return {device["id"]: device for device in json.loads(raw)}
 
 
 def test_switch_multigang_seed_present(tmp_path: Path) -> None:
@@ -51,3 +59,18 @@ def test_single_switch_omits_gang_topics(tmp_path: Path) -> None:
     payload = export_discovery([pump])[0]["payload"]
     assert "gang_count" not in payload
     assert payload["device_class"] == "switch"
+
+
+def test_irrigation_zone_switch_device_pack_entry() -> None:
+    zone = _device_pack().get("switch.irrigation_zone_a")
+
+    assert zone is not None
+    assert zone["name"] == "Irrigation zone A"
+    assert zone["domain"] == "switch"
+    assert zone["area"] == "farm"
+    assert zone["state"] == {"state": "off"}
+    assert zone["adapter"] == "mqtt"
+
+    payload = export_discovery([Device.model_validate(zone)])[0]["payload"]
+    assert payload["device_class"] == "switch"
+    assert payload["command_topic"].endswith("/cmd/switch/irrigation_zone_a")


### PR DESCRIPTION
## Summary
- Adds `switch.irrigation_zone_a` to the HIRI bridge device pack as an MQTT switch for the farm irrigation zone.
- Adds switch-pack test coverage so the new switch is exported with the expected discovery metadata.

## Linked issue / bounty
- Fixes #86
- Claim comment: https://github.com/mergeos-bounties/HIRI/issues/86#issuecomment-4987432540
- MergeOS Claim Token #1 reference: https://github.com/mergeos-bounties/mergeos/issues/1#issuecomment-4987432561

## Problem
HIRI#86 requests an append-only irrigation zone switch entity. The device pack did not yet include `switch.irrigation_zone_a`, so discovery could not expose a controllable irrigation switch for that zone.

## Fix
- Appends the irrigation zone switch device definition with MQTT adapter metadata.
- Extends switch-pack tests to assert the irrigation switch discovery output and command topic.

## Verification
QA-approved validation from the handoff:
- `jq -e '([.[] | select(.id == "switch.irrigation_zone_a")] | length == 1) and (.[] | select(.id == "switch.irrigation_zone_a") | .domain == "switch" and .name == "Irrigation zone A" and .area == "farm" and .state == {"state":"off"} and .adapter == "mqtt")' data/devices.json` -> `true`
- `PYTHONPATH=src python3 ... export_discovery(...)` -> one `switch.irrigation_zone_a` match with `device_class` `switch` and command topic `hiri/cmd/switch/irrigation_zone_a`
- `pytest -q tests/test_switch_pack.py` -> 5 passed
- `ruff check src tests` -> All checks passed
- `pytest -q` -> 89 passed, 1 warning

## Risk and rollback
- Risk is low: this is an append-only device-pack/test change for one new switch entity.
- The full test run has one pre-existing Starlette/httpx deprecation warning noted by QA.
- Rollback is to revert this PR commit, which removes the new device entry and its tests.
