### PR TITLE
Add MQTT-triggered HTTP OTA updates for firmware

### DIFF
--- a/docs/firmware-ota.md
+++ b/docs/firmware-ota.md
@@ -1,0 +1,88 @@
+# Firmware OTA Flow
+
+HIRI firmware listens for OTA commands on:
+
+```text
+hiri/cmd/<device_id>/ota
+```
+
+The update payload can be a plain HTTP URL:
+
+```text
+http://192.168.1.10:8080/firmware.bin
+```
+
+or a JSON document:
+
+```json
+{
+  "url": "http://192.168.1.10:8080/firmware.bin",
+  "version": "2026.07.19",
+  "token": "change-me"
+}
+```
+
+## Build And Host
+
+Build the board-specific binary with PlatformIO:
+
+```bash
+cd packages/firmware
+pio run -e esp32dev
+pio run -e esp8266
+```
+
+Host the binary from a machine on the same trusted network:
+
+```bash
+python3 -m http.server 8080 -d .pio/build/esp32dev
+```
+
+For ESP8266, serve `.pio/build/esp8266/firmware.bin` instead.
+
+## Trigger
+
+Publish the MQTT command to the device-specific OTA topic:
+
+```bash
+mosquitto_pub -h homeassistant.local \
+  -t hiri/cmd/hiri_node_01/ota \
+  -m '{"url":"http://192.168.1.10:8080/firmware.bin","version":"2026.07.19","token":"change-me"}'
+```
+
+If `HIRI_OTA_TOKEN` is configured, the payload token must match before the
+device downloads the binary.
+
+## Status
+
+The firmware publishes OTA state to:
+
+```text
+hiri/state/<device_id>/ota
+```
+
+Example status payload:
+
+```json
+{
+  "state": "downloading",
+  "device_id": "hiri_node_01",
+  "current_version": "dev",
+  "detail": "http://192.168.1.10:8080/firmware.bin version=2026.07.19"
+}
+```
+
+Expected states are:
+
+- `idle` when the device is ready
+- `downloading` while the HTTP update is running
+- `rebooting` after a successful update
+- `error` when validation, authorization, or the HTTP update fails
+
+## Safety Notes
+
+- Use a trusted MQTT broker and authenticated MQTT credentials.
+- Override `HIRI_OTA_TOKEN` with a non-empty per-deployment secret.
+- Host binaries only on a trusted local network or protected endpoint.
+- Match the binary to the physical board environment.
+- Keep a USB flash recovery path for first rollout and failed OTA recovery.

--- a/packages/firmware/README.md
+++ b/packages/firmware/README.md
@@ -16,8 +16,41 @@ Edit `include/hiri_config.h` (WiFi + MQTT broker = Home Assistant Mosquitto).
 ## Features
 
 - HA MQTT discovery for switch + soil + temperature
+- MQTT-triggered HTTP OTA updates with status telemetry
 - Compact telemetry loop (10s)
 - Command topic for relay
+
+## OTA update flow
+
+1. Build a firmware binary for the target board:
+
+```bash
+pio run -e esp32dev
+pio run -e esp8266
+```
+
+2. Host the generated binary on an HTTP endpoint reachable from the ESP board:
+
+```bash
+python3 -m http.server 8080 -d .pio/build/esp32dev
+```
+
+3. Publish an OTA command over MQTT. JSON payloads may include an optional
+`version` for traceability and must include `token` when `HIRI_OTA_TOKEN` is set:
+
+```bash
+mosquitto_pub -h homeassistant.local \
+  -t hiri/cmd/hiri_node_01/ota \
+  -m '{"url":"http://192.168.1.10:8080/firmware.bin","version":"2026.07.19","token":"change-me"}'
+```
+
+The device publishes progress to `hiri/state/<device_id>/ota` as JSON states
+such as `idle`, `downloading`, `rebooting`, or `error`. Home Assistant discovers
+this as an OTA status sensor.
+
+Use OTA only on a trusted broker/network. Set MQTT credentials and override
+`HIRI_OTA_TOKEN` with a non-empty value through build flags for shared
+deployments.
 
 ## Bounties
 

--- a/packages/firmware/include/hiri_config.h
+++ b/packages/firmware/include/hiri_config.h
@@ -22,3 +22,12 @@
 #ifndef HIRI_DEVICE_ID
 #define HIRI_DEVICE_ID "hiri_node_01"
 #endif
+#ifndef HIRI_FIRMWARE_VERSION
+#define HIRI_FIRMWARE_VERSION "dev"
+#endif
+
+// Optional shared secret for MQTT OTA commands. Leave empty only on trusted dev
+// brokers; production deployments should override this via build flags.
+#ifndef HIRI_OTA_TOKEN
+#define HIRI_OTA_TOKEN ""
+#endif

--- a/packages/firmware/src/main.cpp
+++ b/packages/firmware/src/main.cpp
@@ -3,6 +3,7 @@
  * Publishes Home Assistant MQTT discovery + state for:
  *  - switch (relay)
  *  - sensor (fake soil moisture / temperature)
+ *  - OTA status
  *
  * Configure WiFi/MQTT in include/hiri_config.h or build_flags.
  */
@@ -12,8 +13,12 @@
 #include "hiri_config.h"
 
 #if defined(ESP8266)
+#include <ESP8266HTTPClient.h>
 #include <ESP8266WiFi.h>
+#include <ESP8266httpUpdate.h>
 #else
+#include <HTTPClient.h>
+#include <HTTPUpdate.h>
 #include <WiFi.h>
 #endif
 
@@ -30,11 +35,107 @@ String stateTopicSwitch() {
 String cmdTopicSwitch() {
   return String("hiri/cmd/") + HIRI_DEVICE_ID + "/switch";
 }
+String cmdTopicOta() {
+  return String("hiri/cmd/") + HIRI_DEVICE_ID + "/ota";
+}
 String stateTopicSoil() {
   return String("hiri/state/") + HIRI_DEVICE_ID + "/soil";
 }
 String stateTopicTemp() {
   return String("hiri/state/") + HIRI_DEVICE_ID + "/temp";
+}
+String stateTopicOta() {
+  return String("hiri/state/") + HIRI_DEVICE_ID + "/ota";
+}
+
+struct OtaRequest {
+  String url;
+  String token;
+  String version;
+};
+
+void publishOtaStatus(const char *state, const String &detail = "") {
+  if (!mqtt.connected()) return;
+
+  JsonDocument doc;
+  doc["state"] = state;
+  doc["device_id"] = HIRI_DEVICE_ID;
+  doc["current_version"] = HIRI_FIRMWARE_VERSION;
+  if (detail.length() > 0) {
+    doc["detail"] = detail;
+  }
+
+  char buf[384];
+  size_t n = serializeJson(doc, buf, sizeof(buf));
+  mqtt.publish(stateTopicOta().c_str(), (uint8_t *)buf, n, false);
+}
+
+bool parseOtaRequest(const String &msg, OtaRequest &request) {
+  request.url = "";
+  request.token = "";
+  request.version = "";
+
+  String trimmed = msg;
+  trimmed.trim();
+  if (trimmed.length() == 0) return false;
+
+  if (trimmed[0] == '{') {
+    JsonDocument doc;
+    DeserializationError err = deserializeJson(doc, trimmed);
+    if (err) return false;
+    request.url = doc["url"] | "";
+    request.token = doc["token"] | "";
+    request.version = doc["version"] | "";
+  } else {
+    request.url = trimmed;
+  }
+
+  request.url.trim();
+  return request.url.startsWith("http://");
+}
+
+bool isOtaAuthorized(const OtaRequest &request) {
+  const String expectedToken = HIRI_OTA_TOKEN;
+  return expectedToken.length() == 0 || request.token == expectedToken;
+}
+
+void performHttpOta(const OtaRequest &request) {
+  if (!isOtaAuthorized(request)) {
+    publishOtaStatus("error", "OTA token mismatch");
+    return;
+  }
+
+  String detail = request.url;
+  if (request.version.length() > 0) {
+    detail += " version=" + request.version;
+  }
+
+  publishOtaStatus("downloading", detail);
+  mqtt.publish(STATUS_TOPIC, "updating", true);
+  mqtt.loop();
+
+  WiFiClient otaClient;
+#if defined(ESP8266)
+  ESPhttpUpdate.rebootOnUpdate(false);
+  t_httpUpdate_return result = ESPhttpUpdate.update(otaClient, request.url);
+  String error = ESPhttpUpdate.getLastErrorString();
+#else
+  httpUpdate.rebootOnUpdate(false);
+  t_httpUpdate_return result = httpUpdate.update(otaClient, request.url);
+  String error = httpUpdate.getLastErrorString();
+#endif
+
+  if (result == HTTP_UPDATE_OK) {
+    publishOtaStatus("rebooting", "OTA update applied");
+    delay(250);
+    ESP.restart();
+  } else if (result == HTTP_UPDATE_NO_UPDATES) {
+    publishOtaStatus("idle", "No update available");
+    mqtt.publish(STATUS_TOPIC, "online", true);
+  } else {
+    publishOtaStatus("error", error.length() > 0 ? error : "HTTP OTA failed");
+    mqtt.publish(STATUS_TOPIC, "online", true);
+  }
 }
 
 void publishDiscovery() {
@@ -90,6 +191,22 @@ void publishDiscovery() {
     size_t n = serializeJson(doc, buf, sizeof(buf));
     mqtt.publish(topic.c_str(), (uint8_t *)buf, n, true);
   }
+  // OTA status sensor
+  {
+    String topic = String("homeassistant/sensor/hiri/") + HIRI_DEVICE_ID + "_ota/config";
+    JsonDocument doc;
+    doc["name"] = String(HIRI_DEVICE_ID) + " OTA Status";
+    doc["unique_id"] = String(HIRI_DEVICE_ID) + "_ota";
+    doc["state_topic"] = stateTopicOta();
+    doc["value_template"] = "{{ value_json.state }}";
+    doc["json_attributes_topic"] = stateTopicOta();
+    doc["availability_topic"] = STATUS_TOPIC;
+    doc["payload_available"] = "online";
+    doc["payload_not_available"] = "offline";
+    char buf[512];
+    size_t n = serializeJson(doc, buf, sizeof(buf));
+    mqtt.publish(topic.c_str(), (uint8_t *)buf, n, true);
+  }
 }
 
 void onMqttMessage(char *topic, byte *payload, unsigned int length) {
@@ -100,6 +217,14 @@ void onMqttMessage(char *topic, byte *payload, unsigned int length) {
     relayOn = (msg == "ON" || msg == "on" || msg == "1");
     mqtt.publish(stateTopicSwitch().c_str(), relayOn ? "ON" : "OFF", true);
   }
+  if (t == cmdTopicOta()) {
+    OtaRequest request;
+    if (parseOtaRequest(msg, request)) {
+      performHttpOta(request);
+    } else {
+      publishOtaStatus("error", "Invalid OTA payload");
+    }
+  }
 }
 
 void ensureMqtt() {
@@ -108,8 +233,10 @@ void ensureMqtt() {
   if (mqtt.connect(clientId.c_str(), HIRI_MQTT_USER, HIRI_MQTT_PASS, STATUS_TOPIC, 0, true, "offline")) {
     mqtt.publish(STATUS_TOPIC, "online", true);
     mqtt.subscribe(cmdTopicSwitch().c_str());
+    mqtt.subscribe(cmdTopicOta().c_str());
     publishDiscovery();
     mqtt.publish(stateTopicSwitch().c_str(), relayOn ? "ON" : "OFF", true);
+    publishOtaStatus("idle", "ready");
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds an MQTT-triggered HTTP OTA path for the firmware package.
- Publishes OTA status telemetry and Home Assistant discovery for the OTA status sensor.
- Documents the build, local HTTP hosting, MQTT trigger payload, status states, and safety notes.

## Linked issue / bounty
- Fixes #10
- Bounty issue: https://github.com/mergeos-bounties/HIRI/issues/10
- MergeOS claim comment: https://github.com/mergeos-bounties/mergeos/issues/1#issuecomment-5016385825

## Problem
The firmware package had ESP32/ESP8266 MQTT telemetry and relay control, but no documented OTA path for shipping firmware updates over the local network.

## Fix
- Adds `hiri/cmd/<device_id>/ota` handling for plain HTTP URL payloads or JSON payloads with `url`, optional `version`, and optional `token`.
- Adds `HIRI_FIRMWARE_VERSION` and `HIRI_OTA_TOKEN` build-time configuration defaults.
- Runs ESP32/ESP8266 HTTP OTA updates and reports `idle`, `downloading`, `rebooting`, and `error` states on `hiri/state/<device_id>/ota`.
- Adds Home Assistant discovery for OTA status and firmware OTA flow documentation.

## Verification
QA verified the branch with:

```bash
gh issue view 10 --repo mergeos-bounties/HIRI --json number,state,assignees,comments,url,labels
gh pr list --repo mergeos-bounties/HIRI --state open --json number,title,url,headRefName,updatedAt,author
gh search prs --repo mergeos-bounties/HIRI '10 OTA' --state open --json repository,number,title,url,updatedAt --limit 20
gh search prs --repo mergeos-bounties/HIRI 'firmware OTA OR MQTT HTTP' --state open --json repository,number,title,url,updatedAt --limit 20
git diff --check HEAD~1..HEAD
git log -1 --format='%an <%ae>%n%cn <%ce>'
PLATFORMIO_CORE_DIR="$PWD/../../.platformio-core" ../../.venv-pio/bin/pio run -e esp32dev
PLATFORMIO_CORE_DIR="$PWD/../../.platformio-core" ../../.venv-pio/bin/pio run -e esp8266
ruby scripts/board-tracker-csv-guard.rb --validate
```

Results:
- Issue #10 was open, unassigned, and had no comments before the claim comment.
- No open same-surface issue-10 / firmware OTA PR was found in the checked searches.
- `git diff --check HEAD~1..HEAD` passed.
- ESP32 PlatformIO build passed.
- ESP8266 PlatformIO build passed with upstream `elf2bin.py` SyntaxWarnings only.
- Local author and committer identity were `Rajesh Digambar Bagul <102693488+Rajesh270712@users.noreply.github.com>`.

## Risk and rollback
- Validation was compile/static/documentation only; I did not exercise this on physical ESP32/ESP8266 hardware, a live MQTT broker, or an HTTP OTA server.
- OTA currently accepts `http://` URLs for trusted local-network update flows; this PR does not add TLS OTA transport.
- Rollback is a normal revert of this PR, which removes the OTA command/status path and documentation while preserving existing switch and telemetry behavior.