### PR TITLE
Add firmware deep sleep and battery telemetry

### DIFF
--- a/packages/firmware/README.md
+++ b/packages/firmware/README.md
@@ -13,9 +13,34 @@ pio run -e esp8266
 
 Edit `include/hiri_config.h` (WiFi + MQTT broker = Home Assistant Mosquitto).
 
+### Battery and deep sleep
+
+Battery reporting and deep sleep are opt-in so the default firmware keeps the
+relay command topic online continuously.
+
+Set these flags in `include/hiri_config.h` or PlatformIO `build_flags`:
+
+- `HIRI_BATTERY_REPORTING_ENABLED=1` publishes retained voltage and percent
+  states plus Home Assistant discovery sensors.
+- `HIRI_BATTERY_ADC_PIN` selects the ADC pin. Defaults are `A0` on ESP8266 and
+  GPIO 34 on ESP32.
+- `HIRI_BATTERY_ADC_REF_V`, `HIRI_BATTERY_DIVIDER_RATIO`,
+  `HIRI_BATTERY_MIN_V`, and `HIRI_BATTERY_MAX_V` calibrate the voltage divider
+  and percentage estimate. Use a resistor divider that keeps the ADC input below
+  the board limit.
+- `HIRI_DEEP_SLEEP_ENABLED=1` publishes one telemetry sample, flushes MQTT, and
+  enters timer deep sleep.
+- `HIRI_DEEP_SLEEP_INTERVAL_SECONDS` controls the wake interval. ESP8266 boards
+  must wire the wake pin as required by the board.
+
+When deep sleep is enabled, MQTT commands are only available while the device is
+awake. Leave it disabled for relay nodes that need always-on command handling.
+
 ## Features
 
 - HA MQTT discovery for switch + soil + temperature
+- Optional battery voltage/percent reporting
+- Optional timer deep sleep after telemetry publish
 - Compact telemetry loop (10s)
 - Command topic for relay
 

--- a/packages/firmware/include/hiri_config.h
+++ b/packages/firmware/include/hiri_config.h
@@ -22,3 +22,50 @@
 #ifndef HIRI_DEVICE_ID
 #define HIRI_DEVICE_ID "hiri_node_01"
 #endif
+
+// Telemetry cadence for normal continuous mode and each deep-sleep wake cycle.
+#ifndef HIRI_TELEMETRY_INTERVAL_MS
+#define HIRI_TELEMETRY_INTERVAL_MS 10000UL
+#endif
+
+// Keep deep sleep disabled by default so command/relay behavior stays continuous.
+#ifndef HIRI_DEEP_SLEEP_ENABLED
+#define HIRI_DEEP_SLEEP_ENABLED 0
+#endif
+#ifndef HIRI_DEEP_SLEEP_INTERVAL_SECONDS
+#define HIRI_DEEP_SLEEP_INTERVAL_SECONDS 300UL
+#endif
+#ifndef HIRI_MQTT_FLUSH_DELAY_MS
+#define HIRI_MQTT_FLUSH_DELAY_MS 250UL
+#endif
+
+// Battery reporting is opt-in because boards need a wired and calibrated divider.
+#ifndef HIRI_BATTERY_REPORTING_ENABLED
+#define HIRI_BATTERY_REPORTING_ENABLED 0
+#endif
+#ifndef HIRI_BATTERY_ADC_PIN
+#if defined(HIRI_BOARD_ESP8266)
+#define HIRI_BATTERY_ADC_PIN A0
+#else
+#define HIRI_BATTERY_ADC_PIN 34
+#endif
+#endif
+#ifndef HIRI_BATTERY_ADC_MAX
+#if defined(HIRI_BOARD_ESP8266)
+#define HIRI_BATTERY_ADC_MAX 1023.0f
+#else
+#define HIRI_BATTERY_ADC_MAX 4095.0f
+#endif
+#endif
+#ifndef HIRI_BATTERY_ADC_REF_V
+#define HIRI_BATTERY_ADC_REF_V 3.3f
+#endif
+#ifndef HIRI_BATTERY_DIVIDER_RATIO
+#define HIRI_BATTERY_DIVIDER_RATIO 2.0f
+#endif
+#ifndef HIRI_BATTERY_MIN_V
+#define HIRI_BATTERY_MIN_V 3.0f
+#endif
+#ifndef HIRI_BATTERY_MAX_V
+#define HIRI_BATTERY_MAX_V 4.2f
+#endif

--- a/packages/firmware/src/main.cpp
+++ b/packages/firmware/src/main.cpp
@@ -16,6 +16,9 @@
 #else
 #include <WiFi.h>
 #endif
+#if HIRI_DEEP_SLEEP_ENABLED && !defined(ESP8266)
+#include <esp_sleep.h>
+#endif
 
 WiFiClient wifiClient;
 PubSubClient mqtt(wifiClient);
@@ -36,6 +39,20 @@ String stateTopicSoil() {
 String stateTopicTemp() {
   return String("hiri/state/") + HIRI_DEVICE_ID + "/temp";
 }
+String stateTopicBatteryVoltage() {
+  return String("hiri/state/") + HIRI_DEVICE_ID + "/battery_voltage";
+}
+String stateTopicBatteryPercent() {
+  return String("hiri/state/") + HIRI_DEVICE_ID + "/battery_percent";
+}
+
+void addDevice(JsonDocument &doc) {
+  JsonObject dev = doc["device"].to<JsonObject>();
+  dev["identifiers"][0] = HIRI_DEVICE_ID;
+  dev["manufacturer"] = "HIRI";
+  dev["model"] = "HIRI Firmware";
+  dev["name"] = HIRI_DEVICE_ID;
+}
 
 void publishDiscovery() {
   // Switch
@@ -51,11 +68,7 @@ void publishDiscovery() {
     doc["availability_topic"] = STATUS_TOPIC;
     doc["payload_available"] = "online";
     doc["payload_not_available"] = "offline";
-    JsonObject dev = doc["device"].to<JsonObject>();
-    dev["identifiers"][0] = HIRI_DEVICE_ID;
-    dev["manufacturer"] = "HIRI";
-    dev["model"] = "HIRI Firmware";
-    dev["name"] = HIRI_DEVICE_ID;
+    addDevice(doc);
     char buf[512];
     size_t n = serializeJson(doc, buf, sizeof(buf));
     mqtt.publish(topic.c_str(), (uint8_t *)buf, n, true);
@@ -90,6 +103,89 @@ void publishDiscovery() {
     size_t n = serializeJson(doc, buf, sizeof(buf));
     mqtt.publish(topic.c_str(), (uint8_t *)buf, n, true);
   }
+#if HIRI_BATTERY_REPORTING_ENABLED
+  // Battery voltage sensor
+  {
+    String topic = String("homeassistant/sensor/hiri/") + HIRI_DEVICE_ID + "_battery_voltage/config";
+    JsonDocument doc;
+    doc["name"] = String(HIRI_DEVICE_ID) + " Battery Voltage";
+    doc["unique_id"] = String(HIRI_DEVICE_ID) + "_battery_voltage";
+    doc["state_topic"] = stateTopicBatteryVoltage();
+    doc["unit_of_measurement"] = "V";
+    doc["device_class"] = "voltage";
+    doc["state_class"] = "measurement";
+    doc["entity_category"] = "diagnostic";
+    doc["availability_topic"] = STATUS_TOPIC;
+    addDevice(doc);
+    char buf[512];
+    size_t n = serializeJson(doc, buf, sizeof(buf));
+    mqtt.publish(topic.c_str(), (uint8_t *)buf, n, true);
+  }
+  // Battery percentage sensor
+  {
+    String topic = String("homeassistant/sensor/hiri/") + HIRI_DEVICE_ID + "_battery_percent/config";
+    JsonDocument doc;
+    doc["name"] = String(HIRI_DEVICE_ID) + " Battery";
+    doc["unique_id"] = String(HIRI_DEVICE_ID) + "_battery_percent";
+    doc["state_topic"] = stateTopicBatteryPercent();
+    doc["unit_of_measurement"] = "%";
+    doc["device_class"] = "battery";
+    doc["state_class"] = "measurement";
+    doc["entity_category"] = "diagnostic";
+    doc["availability_topic"] = STATUS_TOPIC;
+    addDevice(doc);
+    char buf[512];
+    size_t n = serializeJson(doc, buf, sizeof(buf));
+    mqtt.publish(topic.c_str(), (uint8_t *)buf, n, true);
+  }
+#endif
+}
+
+void publishTelemetry() {
+  if (!mqtt.connected()) return;
+
+  // Simulated sensors — replace with real ADC/I2C in bounties
+  unsigned long now = millis();
+  float soil = 35.0f + (now % 2000) / 100.0f;
+  float temp = 24.0f + (now % 1000) / 200.0f;
+  char buf[16];
+  dtostrf(soil, 0, 1, buf);
+  mqtt.publish(stateTopicSoil().c_str(), buf, true);
+  dtostrf(temp, 0, 1, buf);
+  mqtt.publish(stateTopicTemp().c_str(), buf, true);
+
+#if HIRI_BATTERY_REPORTING_ENABLED
+  int raw = analogRead(HIRI_BATTERY_ADC_PIN);
+  float voltage = (raw / HIRI_BATTERY_ADC_MAX) * HIRI_BATTERY_ADC_REF_V * HIRI_BATTERY_DIVIDER_RATIO;
+  float percent = 0.0f;
+  if (HIRI_BATTERY_MAX_V > HIRI_BATTERY_MIN_V) {
+    percent = (voltage - HIRI_BATTERY_MIN_V) * 100.0f / (HIRI_BATTERY_MAX_V - HIRI_BATTERY_MIN_V);
+    percent = constrain(percent, 0.0f, 100.0f);
+  }
+  dtostrf(voltage, 0, 2, buf);
+  mqtt.publish(stateTopicBatteryVoltage().c_str(), buf, true);
+  dtostrf(percent, 0, 0, buf);
+  mqtt.publish(stateTopicBatteryPercent().c_str(), buf, true);
+#endif
+}
+
+void enterDeepSleep() {
+#if HIRI_DEEP_SLEEP_ENABLED
+  if (mqtt.connected()) {
+    mqtt.publish(STATUS_TOPIC, "offline", true);
+    mqtt.loop();
+    delay(HIRI_MQTT_FLUSH_DELAY_MS);
+    mqtt.disconnect();
+  }
+  WiFi.disconnect(true);
+  Serial.flush();
+#if defined(ESP8266)
+  ESP.deepSleep((uint64_t)HIRI_DEEP_SLEEP_INTERVAL_SECONDS * 1000000ULL);
+#else
+  esp_sleep_enable_timer_wakeup((uint64_t)HIRI_DEEP_SLEEP_INTERVAL_SECONDS * 1000000ULL);
+  esp_deep_sleep_start();
+#endif
+#endif
 }
 
 void onMqttMessage(char *topic, byte *payload, unsigned int length) {
@@ -133,17 +229,13 @@ void loop() {
     mqtt.loop();
   }
   unsigned long now = millis();
-  if (now - lastTelemetry > 10000) {
+  bool telemetryDue = now - lastTelemetry > HIRI_TELEMETRY_INTERVAL_MS;
+#if HIRI_DEEP_SLEEP_ENABLED
+  telemetryDue = telemetryDue || lastTelemetry == 0;
+#endif
+  if (telemetryDue) {
     lastTelemetry = now;
-    if (mqtt.connected()) {
-      // Simulated sensors — replace with real ADC/I2C in bounties
-      float soil = 35.0f + (now % 2000) / 100.0f;
-      float temp = 24.0f + (now % 1000) / 200.0f;
-      char buf[16];
-      dtostrf(soil, 0, 1, buf);
-      mqtt.publish(stateTopicSoil().c_str(), buf, true);
-      dtostrf(temp, 0, 1, buf);
-      mqtt.publish(stateTopicTemp().c_str(), buf, true);
-    }
+    publishTelemetry();
+    enterDeepSleep();
   }
 }


### PR DESCRIPTION
## Summary
- Add optional firmware deep sleep controls for low-power farm-node deployments.
- Add optional battery voltage/percentage telemetry to the firmware MQTT payload.
- Document the feature flags, ADC divider assumptions, and per-board enablement notes.

## Linked issue / bounty
Fixes #9

Bounty: https://github.com/mergeos-bounties/HIRI/issues/9 (50 MRG)

## Problem
The firmware did not expose a low-power mode or battery reporting path, so battery-powered ESP32/ESP8266 deployments could not sleep between publishes or report battery state upstream.

## Fix
- Add compile-time firmware config flags and defaults in `packages/firmware/include/hiri_config.h`.
- Sample the configured battery ADC pin when enabled, estimate voltage/percentage, and include those fields in telemetry JSON.
- Enter ESP32/ESP8266 deep sleep after the publish interval when enabled.
- Update `packages/firmware/README.md` with wiring and feature-flag guidance.

## Verification
- `git diff --check origin/master...HEAD`
- `../../../.venv/bin/pio run -e esp32dev` from `packages/firmware` - passed
- `../../../.venv/bin/pio run -e esp8266` from `packages/firmware` - passed with upstream dependency/Python SyntaxWarnings only
- `../../../.venv/bin/pio run -c .pio-feature.ini -e esp32dev_feature` - passed with `HIRI_BATTERY_REPORTING_ENABLED=1` and `HIRI_DEEP_SLEEP_ENABLED=1`
- `../../../.venv/bin/pio run -c .pio-feature.ini -e esp8266_feature` - passed with the same feature flags and upstream dependency/Python SyntaxWarnings only
- `ruby scripts/board-tracker-csv-guard.rb --validate` - passed

## Risk and rollback
- The new deep sleep and battery reporting paths default to disabled, so existing firmware behavior should remain unchanged unless the flags are enabled.
- Hardware runtime behavior, battery-divider calibration, MQTT retained-topic behavior, and Home Assistant/broker behavior were not proven without physical ESP32/ESP8266 hardware, a battery divider, an MQTT broker, and a Home Assistant instance.
- Rollback is a straight revert of commit `5f2bf16d75ea65b67bc51f81d861841def832369`.

## Maintainer attention
- Please verify the default ADC pin/divider constants match your intended reference hardware before enabling this by default.
