### PR TITLE
Add optional TLS MQTT support for firmware

### DIFF
--- a/packages/firmware/README.md
+++ b/packages/firmware/README.md
@@ -7,11 +7,29 @@ PlatformIO project for **ESP32** and **ESP8266**.
 ```bash
 pio run -e esp32dev
 pio run -e esp8266
+pio run -e esp32dev_tls
+pio run -e esp8266_tls
 ```
 
 ## Configure
 
 Edit `include/hiri_config.h` (WiFi + MQTT broker = Home Assistant Mosquitto).
+
+MQTT uses plaintext port `1883` by default. Enable TLS at build time when your
+broker exposes secure MQTT:
+
+```ini
+build_flags =
+  -DHIRI_MQTT_TLS=1
+  -DHIRI_MQTT_CA_CERT="\"-----BEGIN CERTIFICATE-----\\n...\\n-----END CERTIFICATE-----\\n\""
+```
+
+When `HIRI_MQTT_TLS=1`, the default MQTT port becomes `8883`. Override
+`HIRI_MQTT_PORT` if your broker uses a different TLS port.
+
+For local development with a self-signed broker certificate, you can compile
+with `-DHIRI_MQTT_TLS_INSECURE=1` to skip certificate validation. Do not use
+that mode for production Home Assistant installs.
 
 ## Features
 

--- a/packages/firmware/include/hiri_config.h
+++ b/packages/firmware/include/hiri_config.h
@@ -10,8 +10,21 @@
 #ifndef HIRI_MQTT_HOST
 #define HIRI_MQTT_HOST "homeassistant.local"
 #endif
+#ifndef HIRI_MQTT_TLS
+#define HIRI_MQTT_TLS 0
+#endif
+#ifndef HIRI_MQTT_TLS_INSECURE
+#define HIRI_MQTT_TLS_INSECURE 0
+#endif
+#ifndef HIRI_MQTT_CA_CERT
+#define HIRI_MQTT_CA_CERT ""
+#endif
 #ifndef HIRI_MQTT_PORT
+#if HIRI_MQTT_TLS
+#define HIRI_MQTT_PORT 8883
+#else
 #define HIRI_MQTT_PORT 1883
+#endif
 #endif
 #ifndef HIRI_MQTT_USER
 #define HIRI_MQTT_USER ""

--- a/packages/firmware/platformio.ini
+++ b/packages/firmware/platformio.ini
@@ -11,7 +11,21 @@ platform = espressif32
 board = esp32dev
 build_flags = -DHIRI_BOARD_ESP32
 
+[env:esp32dev_tls]
+platform = espressif32
+board = esp32dev
+build_flags =
+  -DHIRI_BOARD_ESP32
+  -DHIRI_MQTT_TLS=1
+
 [env:esp8266]
 platform = espressif8266
 board = nodemcuv2
 build_flags = -DHIRI_BOARD_ESP8266
+
+[env:esp8266_tls]
+platform = espressif8266
+board = nodemcuv2
+build_flags =
+  -DHIRI_BOARD_ESP8266
+  -DHIRI_MQTT_TLS=1

--- a/packages/firmware/src/main.cpp
+++ b/packages/firmware/src/main.cpp
@@ -13,11 +13,25 @@
 
 #if defined(ESP8266)
 #include <ESP8266WiFi.h>
+#if HIRI_MQTT_TLS
+#include <WiFiClientSecureBearSSL.h>
+#endif
 #else
 #include <WiFi.h>
+#if HIRI_MQTT_TLS
+#include <WiFiClientSecure.h>
+#endif
 #endif
 
+#if HIRI_MQTT_TLS
+#if defined(ESP8266)
+BearSSL::WiFiClientSecure wifiClient;
+#else
+WiFiClientSecure wifiClient;
+#endif
+#else
 WiFiClient wifiClient;
+#endif
 PubSubClient mqtt(wifiClient);
 
 const char *STATUS_TOPIC = "hiri/status";
@@ -35,6 +49,19 @@ String stateTopicSoil() {
 }
 String stateTopicTemp() {
   return String("hiri/state/") + HIRI_DEVICE_ID + "/temp";
+}
+
+void configureMqttTransport() {
+#if HIRI_MQTT_TLS
+#if HIRI_MQTT_TLS_INSECURE
+  wifiClient.setInsecure();
+#elif defined(ESP8266)
+  static BearSSL::X509List caCert(HIRI_MQTT_CA_CERT);
+  wifiClient.setTrustAnchors(&caCert);
+#else
+  wifiClient.setCACert(HIRI_MQTT_CA_CERT);
+#endif
+#endif
 }
 
 void publishDiscovery() {
@@ -122,6 +149,7 @@ void setup() {
     delay(250);
     tries++;
   }
+  configureMqttTransport();
   mqtt.setServer(HIRI_MQTT_HOST, HIRI_MQTT_PORT);
   mqtt.setCallback(onMqttMessage);
   mqtt.setBufferSize(1024);


### PR DESCRIPTION
## Summary
- Adds optional TLS MQTT support for ESP32/ESP8266 firmware builds.
- Keeps existing plaintext MQTT behavior as the default.
- Documents TLS enablement, CA certificate configuration, and local insecure TLS testing.

## Linked issue / bounty
- Fixes #11
- Bounty issue: https://github.com/mergeos-bounties/HIRI/issues/11
- HIRI claim comment: https://github.com/mergeos-bounties/HIRI/issues/11#issuecomment-5016598046
- MergeOS claim comment: https://github.com/mergeos-bounties/mergeos/issues/1#issuecomment-5016598120

## Problem
The firmware only used plaintext MQTT clients, so production deployments could not compile an ESP32/ESP8266 firmware variant that connects to TLS-enabled MQTT brokers.

## Fix
- Adds `HIRI_MQTT_TLS`, `HIRI_MQTT_TLS_INSECURE`, and `HIRI_MQTT_CA_CERT` build-time configuration options.
- Defaults TLS builds to MQTT port `8883` while preserving port `1883` for the existing non-TLS default.
- Uses `WiFiClientSecure` on ESP32 and `BearSSL::WiFiClientSecure` on ESP8266 only when TLS is enabled.
- Adds `esp32dev_tls` and `esp8266_tls` PlatformIO environments.
- Updates the firmware README with TLS, CA certificate, and local/self-signed broker guidance.

## Verification
QA verified the branch with:

```bash
gh issue view 11 --repo mergeos-bounties/HIRI --json number,title,state,comments,assignees,labels,url,updatedAt,body
gh pr list --repo mergeos-bounties/HIRI --state open --limit 100 --json number,title,url,headRefName,updatedAt,body
gh search prs --repo mergeos-bounties/HIRI '11 TLS MQTT' --state open --json repository,number,title,url,updatedAt --limit 20
gh search prs --repo mergeos-bounties/HIRI 'WiFiClientSecure OR secure MQTT OR TLS' --state open --json repository,number,title,url,updatedAt --limit 20
git diff --check origin/master...HEAD
PLATFORMIO_CORE_DIR="$PWD/../../.platformio-core" ../../.venv-pio/bin/pio project config
PLATFORMIO_CORE_DIR="$PWD/../../.platformio-core" ../../.venv-pio/bin/pio run -e esp32dev -e esp8266
PLATFORMIO_CORE_DIR="$PWD/../../.platformio-core" ../../.venv-pio/bin/pio run -e esp32dev_tls -e esp8266_tls
```

Results:
- Issue #11 was open, unassigned, and had no comments before the claim comment.
- No open same-surface issue-11 / TLS MQTT PR was found in the checked searches.
- `git diff --check origin/master...HEAD` passed.
- All four PlatformIO environments resolved.
- ESP32 and ESP8266 default builds passed.
- ESP32 and ESP8266 TLS builds passed.
- Commit attribution maps both author and committer to `Rajesh270712`.

## Risk and rollback
- Validation was compile/static/documentation only; I did not exercise this on physical ESP32/ESP8266 hardware.
- I did not run a live Home Assistant/Mosquitto TLS broker test or runtime certificate-validation test.
- Adjacent upstream PR #119 for issue #10 also touches firmware files and may create merge conflicts, but it implements MQTT-triggered OTA rather than TLS MQTT.
- Rollback is a normal revert of commit `42c03c07a628736872ae30e3ce39e79da284a076`.