### PR TITLE
Fix: add humidifier seed device with modes for HA discovery

### DIFF
--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -167,6 +167,19 @@ def default_seed_devices() -> list[Device]:
             attributes={"preset_modes": ["low", "medium", "high", "breeze"]},
         ),
         Device(
+            id="humidifier.bedroom",
+            name="Bedroom humidifier",
+            domain="humidifier",
+            model="HIRI-HUMID",
+            area="bedroom",
+            state={"state": "off", "current_humidity": 45, "humidity": 50, "mode": "auto"},
+            attributes={
+                "min_humidity": 30,
+                "max_humidity": 80,
+                "modes": ["auto", "sleep", "boost", "off"],
+            },
+        ),
+        Device(
             id="media_player.tv_living",
             name="Living TV",
             domain="media_player",


### PR DESCRIPTION
## Summary
The humidifier domain is defined and partially handled in discovery.py, but no seed device exists in registry.py and command coverage/tests are missing. Minimal fix: add a humidifier seed device with modes to demonstrate discovery and command handling.

**Fixes:** https://github.com/mergeos-bounties/HIRI/issues/36

---

### Changes Made
- `packages/bridge/src/hiri_bridge/devices/registry.py`

---

> **Bounty Claim:** If this PR resolves the issue and is eligible for the bounty, please send the payout via PayPal: https://www.paypal.com/paypalme/plutoxvii
