### PR TITLE
Fix: add seed humidifier device to bridge registry for HA discovery

### DIFF
--- a/packages/bridge/src/hiri_bridge/devices/registry.py
+++ b/packages/bridge/src/hiri_bridge/devices/registry.py
@@ -167,6 +167,19 @@ def default_seed_devices() -> list[Device]:
             attributes={"preset_modes": ["low", "medium", "high", "breeze"]},
         ),
         Device(
+            id="humidifier.bedroom",
+            name="Bedroom humidifier",
+            domain="humidifier",
+            model="HIRI-HUMID",
+            area="bedroom",
+            state={"state": "off", "current_humidity": 45, "humidity": 50, "mode": "auto"},
+            attributes={
+                "min_humidity": 30,
+                "max_humidity": 80,
+                "modes": ["auto", "sleep", "eco"],
+            },
+        ),
+        Device(
             id="media_player.tv_living",
             name="Living TV",
             domain="media_player",


### PR DESCRIPTION
## Summary
The humidifier domain is defined and partially supported in discovery, but no seed device exists in the registry, so HA discovery and web UI cannot show a humidifier. Adding a seed humidifier device satisfies the acceptance criteria minimally.

**Fixes:** https://github.com/mergeos-bounties/HIRI/issues/36

---

### Changes Made
- `packages/bridge/src/hiri_bridge/devices/registry.py`

---

> **Bounty Claim:** If this PR resolves the issue and is eligible for the bounty, please send the payout via PayPal: https://www.paypal.com/paypalme/plutoxvii
