### PR TITLE
Add Matter adapter research and scaffold

### DIFF
--- a/docs/MATTER.md
+++ b/docs/MATTER.md
@@ -1,0 +1,124 @@
+# Matter adapter direction
+
+HIRI's Matter integration starts as an offline, transport-neutral scaffold. It
+maps controller-provided Matter endpoint snapshots into the existing HIRI
+`Device` registry without commissioning devices, storing fabric credentials, or
+opening a network connection.
+
+Matter is an IP-based application-layer standard with a shared data and
+interaction model. The Connectivity Standards Alliance released Matter 1.6 in
+June 2026, so HIRI keeps the adapter boundary version-neutral instead of binding
+the bridge to one generated SDK revision.
+
+## Architecture
+
+```text
+Matter device
+    |
+    | commissioning, fabric security, subscriptions
+    v
+Matter controller server
+    |
+    | normalized node/endpoint snapshots
+    v
+MatterNodeProvider -> MatterAdapter -> HIRI DeviceRegistry
+                                      |-> REST API
+                                      `-> Home Assistant MQTT discovery
+```
+
+The controller server owns commissioning, certificates, fabric storage, device
+attestation, and attribute subscriptions. HIRI owns only the conversion from a
+normalized endpoint snapshot to its local device model.
+
+The initial implementation in
+`packages/bridge/src/hiri_bridge/adapters/matter.py` includes:
+
+- `MatterNodeProvider`, the future live-client boundary;
+- `MatterAdapter`, which consumes provider snapshots or an offline fixture;
+- a conservative Matter device-type to HIRI domain map;
+- normalized node, endpoint, device type, and attribute metadata on every
+  imported device.
+
+No Matter SDK, controller, hardware, account, or network access is required for
+the scaffold:
+
+```powershell
+cd packages\bridge
+hiri-bridge adapters list
+hiri-bridge adapters import matter
+pytest -q tests\test_matter_adapter.py
+```
+
+## Snapshot contract
+
+A provider returns one dictionary per Matter endpoint:
+
+```json
+{
+  "node_id": 1001,
+  "endpoint_id": 1,
+  "device_type": "dimmable_light",
+  "name": "Living-room lamp",
+  "vendor": "Example vendor",
+  "product": "Example lamp",
+  "area": "living_room",
+  "reachable": true,
+  "attributes": {
+    "on_off": true,
+    "current_level": 180
+  }
+}
+```
+
+Transport implementations normalize SDK-specific numeric device types,
+clusters, and attribute names into this contract. Unknown future device types
+fall back to the HIRI `sensor` domain while retaining their original Matter
+metadata.
+
+## Initial mapping
+
+| Matter device type | HIRI domain |
+| --- | --- |
+| On/Off, dimmable, color-temperature, extended-color light | `light` |
+| On/Off or dimmable plug-in unit | `switch` |
+| Contact sensor | `binary_sensor` |
+| Temperature sensor | `sensor` |
+| Door lock | `lock` |
+| Thermostat | `climate` |
+| Window covering | `cover` |
+| Fan | `fan` |
+
+## Live upgrade path
+
+1. Implement `MatterNodeProvider` as a client for a dedicated Matter controller
+   server. Prefer its WebSocket API over embedding a platform-specific Matter
+   SDK in HIRI.
+2. Normalize nodes, endpoints, device types, clusters, and attributes at the
+   provider boundary, then reuse `MatterAdapter` unchanged.
+3. Add reconnect and attribute-subscription handling. Reconcile snapshots into
+   `DeviceRegistry` using stable `node_id + endpoint_id` identifiers.
+4. Add command writes only after an explicit device-type allowlist and tests for
+   every cluster mapping.
+5. Keep commissioning in the controller server. Never log setup codes or store
+   fabric keys in `devices.json`.
+
+The current Python Matter Server provides a certified controller component and a
+WebSocket client/server API, but is in maintenance mode while its successor is
+being built on Matter.js. HIRI's provider boundary avoids coupling to either
+implementation.
+
+## Primary references
+
+- [Connectivity Standards Alliance: Matter 1.6 release](https://csa-iot.org/newsroom/matter-1-6-enables-more-intuitive-setup-multi-ecosystem-experiences-and-context-driven-control/)
+- [Official Matter SDK: connectedhomeip](https://github.com/project-chip/connectedhomeip)
+- [Open Home Foundation Python Matter Server](https://github.com/matter-js/python-matter-server)
+- [Matter.js Server successor](https://github.com/matter-js/matterjs-server)
+
+## Security boundaries
+
+- Offline fixture mode is the default.
+- HIRI does not commission devices or create a Matter fabric.
+- HIRI does not persist setup codes, fabric credentials, or controller tokens.
+- Live network access must be explicitly configured in a future provider.
+- State-changing commands remain disabled until they have an allowlist and
+  device-type-specific tests.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,7 +13,7 @@
 - [ ] Live MQTT client (paho) optional  
 - [ ] HA WebSocket event stream  
 - [ ] OTA for firmware  
-- [ ] Matter bridge adapter stub  
+- [x] Matter bridge adapter stub
 
 ## v0.3
 

--- a/packages/bridge/README.md
+++ b/packages/bridge/README.md
@@ -7,3 +7,6 @@ pip install -e ".[dev,api]"
 hiri-bridge demo
 hiri-bridge serve --port 8780
 ```
+
+Matter adapter architecture and the offline scaffold contract are documented in
+[`../../docs/MATTER.md`](../../docs/MATTER.md).

--- a/packages/bridge/src/hiri_bridge/adapters/__init__.py
+++ b/packages/bridge/src/hiri_bridge/adapters/__init__.py
@@ -1,4 +1,4 @@
-"""Bridge adapters: local, HA REST/WS, MQTT, Zigbee2MQTT, Tuya."""
+"""Bridge adapters: local, HA REST/WS, MQTT, Zigbee2MQTT, Tuya, Matter."""
 
 from hiri_bridge.adapters.catalog import import_from_adapter, list_adapters
 

--- a/packages/bridge/src/hiri_bridge/adapters/catalog.py
+++ b/packages/bridge/src/hiri_bridge/adapters/catalog.py
@@ -7,6 +7,7 @@ from typing import Any
 from hiri_bridge.adapters.ha_rest import HomeAssistantRestAdapter
 from hiri_bridge.adapters.ha_ws import HomeAssistantWebSocketAdapter
 from hiri_bridge.adapters.local import LocalAdapter
+from hiri_bridge.adapters.matter import MatterAdapter
 from hiri_bridge.adapters.mqtt_pub import MqttDiscoveryPublisher
 from hiri_bridge.adapters.tuya import TuyaAdapter
 from hiri_bridge.adapters.z2m import Zigbee2MqttAdapter
@@ -60,8 +61,8 @@ def list_adapters() -> list[dict[str, Any]]:
             "name": "matter",
             "kind": "scaffold",
             "live": False,
-            "description": "Matter bridge (scaffold only)",
-            "status": "planned",
+            "description": "Matter node snapshot mapping (fixture offline)",
+            "status": MatterAdapter().status(),
         },
     ]
     return rows
@@ -81,4 +82,6 @@ def import_from_adapter(name: str) -> list:
         return HomeAssistantWebSocketAdapter().list_remote()
     if key == "mqtt":
         return []  # mqtt is publish path, not import
+    if key == "matter":
+        return MatterAdapter().list_remote()
     raise ValueError(f"unknown adapter: {name}")

--- a/packages/bridge/src/hiri_bridge/adapters/matter.py
+++ b/packages/bridge/src/hiri_bridge/adapters/matter.py
@@ -1,0 +1,141 @@
+"""Offline Matter adapter scaffold with a transport-neutral node snapshot contract."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Protocol
+
+from hiri_bridge.devices.types import Device
+
+
+MATTER_DEVICE_TYPE_MAP: dict[str, str] = {
+    "on_off_light": "light",
+    "dimmable_light": "light",
+    "color_temperature_light": "light",
+    "extended_color_light": "light",
+    "on_off_plug_in_unit": "switch",
+    "dimmable_plug_in_unit": "switch",
+    "contact_sensor": "binary_sensor",
+    "temperature_sensor": "sensor",
+    "door_lock": "lock",
+    "thermostat": "climate",
+    "window_covering": "cover",
+    "fan": "fan",
+}
+
+MATTER_NODE_FIXTURE: list[dict[str, Any]] = [
+    {
+        "node_id": 1001,
+        "endpoint_id": 1,
+        "device_type": "dimmable_light",
+        "name": "Matter living-room lamp",
+        "vendor": "HIRI fixture",
+        "product": "dimmable-light",
+        "area": "living_room",
+        "reachable": True,
+        "attributes": {"on_off": True, "current_level": 180},
+    },
+    {
+        "node_id": 1002,
+        "endpoint_id": 1,
+        "device_type": "contact_sensor",
+        "name": "Matter front-door contact",
+        "vendor": "HIRI fixture",
+        "product": "contact-sensor",
+        "area": "entry",
+        "reachable": True,
+        "attributes": {"contact": False},
+    },
+    {
+        "node_id": 1003,
+        "endpoint_id": 1,
+        "device_type": "thermostat",
+        "name": "Matter hallway thermostat",
+        "vendor": "HIRI fixture",
+        "product": "thermostat",
+        "area": "hallway",
+        "reachable": True,
+        "attributes": {"local_temperature": 21.4, "occupied_heating_setpoint": 22.0},
+    },
+]
+
+
+class MatterNodeProvider(Protocol):
+    """Boundary implemented later by a Matter Server WebSocket client."""
+
+    def list_nodes(self) -> list[dict[str, Any]]:
+        """Return normalized Matter endpoint snapshots."""
+        ...
+
+
+class MatterAdapter:
+    name = "matter"
+
+    def __init__(
+        self,
+        provider: MatterNodeProvider | None = None,
+        fixture_nodes: Iterable[dict[str, Any]] | None = None,
+    ):
+        self.provider = provider
+        self.fixture_nodes = (
+            list(fixture_nodes) if fixture_nodes is not None else MATTER_NODE_FIXTURE
+        )
+
+    def status(self) -> str:
+        return "provider configured" if self.provider is not None else "fixture ready"
+
+    def list_remote(self) -> list[Device]:
+        rows = self.provider.list_nodes() if self.provider is not None else self.fixture_nodes
+        return [matter_node_to_device(row) for row in rows]
+
+    def push_state(self, device: Device) -> None:
+        """Command writes remain out of scope until a live controller provider is added."""
+        return None
+
+
+def matter_node_to_device(node: dict[str, Any]) -> Device:
+    """Map one normalized Matter endpoint snapshot to the HIRI device contract."""
+    node_id = int(node["node_id"])
+    endpoint_id = int(node.get("endpoint_id", 0))
+    device_type = str(node.get("device_type") or "unknown").strip().lower()
+    domain = MATTER_DEVICE_TYPE_MAP.get(device_type, "sensor")
+    attributes = dict(node.get("attributes") or {})
+
+    return Device(
+        id=f"{domain}.matter_{node_id}_{endpoint_id}",
+        name=str(node.get("name") or f"Matter {node_id}/{endpoint_id}"),
+        domain=domain,
+        manufacturer=str(node.get("vendor") or "Matter"),
+        model=str(node.get("product") or device_type),
+        area=str(node.get("area") or "home"),
+        online=bool(node.get("reachable", True)),
+        state=_state_for_domain(domain, attributes),
+        attributes={
+            "matter_node_id": node_id,
+            "matter_endpoint_id": endpoint_id,
+            "matter_device_type": device_type,
+            "matter_attributes": attributes,
+        },
+        adapter="matter",
+    )
+
+
+def _state_for_domain(domain: str, attributes: dict[str, Any]) -> dict[str, Any]:
+    if domain in {"light", "switch"}:
+        state = {"state": "on" if attributes.get("on_off") else "off"}
+        if "current_level" in attributes:
+            state["brightness"] = attributes["current_level"]
+        return state
+    if domain == "binary_sensor":
+        return {"state": "on" if attributes.get("contact") else "off"}
+    if domain == "climate":
+        return {
+            "temperature": attributes.get("local_temperature"),
+            "target_temperature": attributes.get("occupied_heating_setpoint"),
+        }
+    if domain == "lock":
+        return {"state": attributes.get("lock_state", "unknown")}
+    if domain == "cover":
+        return {"position": attributes.get("current_position")}
+    if domain == "fan":
+        return {"state": "on" if attributes.get("fan_mode") else "off"}
+    return {"value": attributes.get("measured_value")}

--- a/packages/bridge/src/hiri_bridge/cli.py
+++ b/packages/bridge/src/hiri_bridge/cli.py
@@ -286,7 +286,7 @@ def adapters_list() -> None:
 
 @adapters_app.command("import")
 def adapters_import(
-    name: str = typer.Argument(..., help="z2m | tuya | ha_rest | ha_ws"),
+    name: str = typer.Argument(..., help="z2m | tuya | ha_rest | ha_ws | matter"),
 ) -> None:
     reg = _registry()
     try:

--- a/packages/bridge/tests/test_matter_adapter.py
+++ b/packages/bridge/tests/test_matter_adapter.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any
+
+from hiri_bridge.adapters import import_from_adapter, list_adapters
+from hiri_bridge.adapters.matter import MatterAdapter, matter_node_to_device
+
+
+class FakeMatterProvider:
+    def list_nodes(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "node_id": 42,
+                "endpoint_id": 2,
+                "device_type": "door_lock",
+                "name": "Test lock",
+                "vendor": "Fixture vendor",
+                "product": "lock-v1",
+                "reachable": False,
+                "attributes": {"lock_state": "locked"},
+            }
+        ]
+
+
+def test_fixture_maps_matter_endpoints_to_hiri_devices() -> None:
+    devices = MatterAdapter().list_remote()
+
+    assert {device.domain for device in devices} == {"light", "binary_sensor", "climate"}
+    assert all(device.adapter == "matter" for device in devices)
+    assert devices[0].attributes["matter_node_id"] == 1001
+    assert devices[0].state == {"state": "on", "brightness": 180}
+
+
+def test_provider_boundary_is_injectable_and_offline() -> None:
+    devices = MatterAdapter(provider=FakeMatterProvider()).list_remote()
+
+    assert len(devices) == 1
+    assert devices[0].id == "lock.matter_42_2"
+    assert devices[0].online is False
+    assert devices[0].state == {"state": "locked"}
+
+
+def test_unknown_matter_device_type_falls_back_to_sensor() -> None:
+    device = matter_node_to_device(
+        {
+            "node_id": 88,
+            "device_type": "future_device",
+            "attributes": {"measured_value": 7},
+        }
+    )
+
+    assert device.domain == "sensor"
+    assert device.state == {"value": 7}
+
+
+def test_matter_adapter_is_available_from_catalog() -> None:
+    row = next(adapter for adapter in list_adapters() if adapter["name"] == "matter")
+
+    assert row["status"] == "fixture ready"
+    assert row["live"] is False
+    assert import_from_adapter("matter")


### PR DESCRIPTION
## Summary

- add a transport-neutral Matter adapter scaffold backed by offline endpoint fixtures
- map normalized Matter device types and attributes into HIRI `Device` records
- expose Matter through the adapter catalog and `adapters import matter`
- document architecture, security boundaries, device mapping, and the live WebSocket upgrade path
- add focused tests for fixture mapping, provider injection, future-device fallback, and catalog integration

## Why

HIRI advertised Matter as a planned adapter, but the catalog entry had no implementation, package boundary, documentation, or tests. The new `MatterNodeProvider` boundary keeps commissioning and fabric ownership in a dedicated Matter controller server while allowing HIRI to consume normalized snapshots.

## User impact

Developers can exercise the complete Matter-to-HIRI mapping offline today. A future Matter Server client can be injected without changing the device registry or Home Assistant export paths. The scaffold performs no commissioning, network access, credential storage, or state-changing commands.

## Validation

- `pytest -q --cov=hiri_bridge --cov-fail-under=60` — 103 passed, 64.95% coverage
- `ruff check src tests`
- `hiri-bridge demo`
- `python -m compileall -q src tests`

## Research

- [CSA Matter 1.6 release](https://csa-iot.org/newsroom/matter-1-6-enables-more-intuitive-setup-multi-ecosystem-experiences-and-context-driven-control/)
- [Official connectedhomeip SDK](https://github.com/project-chip/connectedhomeip)
- [Open Home Foundation Python Matter Server](https://github.com/matter-js/python-matter-server)
- [Matter.js Server successor](https://github.com/matter-js/matterjs-server)

Fixes #7
