### PR TITLE
Make MQTT live publishing reliable

### DIFF
--- a/docs/mosquitto-dev.conf
+++ b/docs/mosquitto-dev.conf
@@ -1,0 +1,4 @@
+# Local Docker Desktop smoke test only. Do not expose this listener publicly.
+listener 1883
+allow_anonymous true
+persistence false

--- a/docs/mqtt-discovery.md
+++ b/docs/mqtt-discovery.md
@@ -1,9 +1,48 @@
 # HA MQTT Discovery Setup Guide
 
 ## Prerequisites
+
 - Home Assistant running
 - MQTT broker configured (e.g., Mosquitto)
 - HIRI device connected to network
+
+## Docker Desktop smoke test on Windows
+
+The repository includes an anonymous broker configuration for local development
+only. It binds the published Docker port to loopback so the broker is not exposed
+to the LAN.
+
+From the repository root in PowerShell:
+
+```powershell
+$repoRoot = (Get-Location).Path
+docker run --rm --name hiri-mosquitto `
+  -p 127.0.0.1:1883:1883 `
+  --mount "type=bind,source=$repoRoot\docs\mosquitto-dev.conf,target=/mosquitto/config/mosquitto.conf,readonly" `
+  eclipse-mosquitto:2
+```
+
+In a second PowerShell terminal:
+
+```powershell
+cd packages\bridge
+pip install -e ".[mqtt]"
+hiri-bridge mqtt publish --live --host 127.0.0.1 --port 1883
+```
+
+The command publishes retained Home Assistant discovery, state, and HIRI
+availability messages at QoS 1. It waits for every Paho publish receipt before
+disconnecting.
+
+Verify a retained discovery message:
+
+```powershell
+docker exec hiri-mosquitto mosquitto_sub `
+  -t "homeassistant/#" -C 1 -v
+```
+
+Stop the foreground broker with `Ctrl+C`. Replace the anonymous development
+configuration with authentication and TLS before using any non-loopback broker.
 
 ## Setup Steps
 
@@ -21,6 +60,12 @@ mqtt:
 ```
 
 ## Troubleshooting
+
 - Check MQTT broker logs
 - Verify device is publishing to discovery topic
 - Ensure HA discovery is enabled
+
+## References
+
+- [Eclipse Paho Python network loop and publish receipts](https://eclipse.dev/paho/files/paho.mqtt.python/html/index.html)
+- [Eclipse Mosquitto documentation](https://mosquitto.org/documentation/)

--- a/packages/bridge/README.md
+++ b/packages/bridge/README.md
@@ -6,4 +6,8 @@ Runnable Home Assistant–oriented bridge with a broad device type registry.
 pip install -e ".[dev,api]"
 hiri-bridge demo
 hiri-bridge serve --port 8780
+hiri-bridge mqtt publish --dry-run
 ```
+
+For a local live publish smoke test with Docker Desktop and Mosquitto, see
+[`../../docs/mqtt-discovery.md`](../../docs/mqtt-discovery.md).

--- a/packages/bridge/src/hiri_bridge/adapters/mqtt_pub.py
+++ b/packages/bridge/src/hiri_bridge/adapters/mqtt_pub.py
@@ -4,10 +4,31 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any
+from collections.abc import Callable
+from typing import Any, Protocol
 
 from hiri_bridge.devices.types import Device
 from hiri_bridge.ha.discovery import discovery_payload, discovery_topic, state_topic
+
+
+class MqttPublishReceipt(Protocol):
+    def wait_for_publish(self, timeout: float | None = None) -> Any: ...
+
+
+class MqttClient(Protocol):
+    def username_pw_set(self, username: str, password: str) -> Any: ...
+
+    def connect(self, host: str, port: int, keepalive: int) -> Any: ...
+
+    def loop_start(self) -> Any: ...
+
+    def publish(
+        self, topic: str, payload: str, qos: int = 0, retain: bool = False
+    ) -> MqttPublishReceipt: ...
+
+    def disconnect(self) -> Any: ...
+
+    def loop_stop(self) -> Any: ...
 
 
 class MqttDiscoveryPublisher:
@@ -19,13 +40,21 @@ class MqttDiscoveryPublisher:
         port: int | None = None,
         username: str | None = None,
         password: str | None = None,
+        client_factory: Callable[[], MqttClient] | None = None,
+        publish_timeout: float = 5.0,
+        qos: int = 1,
     ):
         self.host = host or os.environ.get("HIRI_MQTT_HOST", "127.0.0.1")
         self.port = int(port or os.environ.get("HIRI_MQTT_PORT", "1883"))
         self.username = username or os.environ.get("HIRI_MQTT_USER") or ""
         self.password = password or os.environ.get("HIRI_MQTT_PASSWORD") or ""
+        self.client_factory = client_factory
+        self.publish_timeout = publish_timeout
+        self.qos = qos
 
     def status(self) -> str:
+        if self.client_factory is not None:
+            return f"client ready → {self.host}:{self.port}"
         try:
             import paho.mqtt.client  # noqa: F401
 
@@ -48,6 +77,7 @@ class MqttDiscoveryPublisher:
                     "topic": discovery_topic(d),
                     "payload": discovery_payload(d),
                     "retain": True,
+                    "qos": self.qos,
                     "kind": "discovery",
                 }
             )
@@ -56,6 +86,7 @@ class MqttDiscoveryPublisher:
                     "topic": state_topic(d),
                     "payload": d.state if d.state else {"state": "unknown"},
                     "retain": True,
+                    "qos": self.qos,
                     "kind": "state",
                 }
             )
@@ -64,6 +95,7 @@ class MqttDiscoveryPublisher:
                 "topic": "hiri/status",
                 "payload": "online",
                 "retain": True,
+                "qos": self.qos,
                 "kind": "availability",
             }
         )
@@ -81,28 +113,63 @@ class MqttDiscoveryPublisher:
                 "truncated": len(messages) > 40,
             }
         try:
-            import paho.mqtt.client as mqtt
-        except ImportError as exc:
+            client = self._new_client()
+        except RuntimeError as exc:
             return {
                 "ok": False,
-                "error": 'paho-mqtt not installed; pip install -e ".[mqtt]" or use dry_run',
+                "error": str(exc),
                 "detail": str(exc),
             }
 
-        client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
-        if self.username:
-            client.username_pw_set(self.username, self.password)
-        client.connect(self.host, self.port, 30)
         published = 0
-        for m in messages:
-            payload = m["payload"]
-            body = payload if isinstance(payload, str) else json.dumps(payload)
-            client.publish(m["topic"], body, retain=bool(m.get("retain")))
-            published += 1
-        client.disconnect()
-        return {
-            "ok": True,
-            "dry_run": False,
-            "broker": f"{self.host}:{self.port}",
-            "published": published,
-        }
+        connected = False
+        loop_started = False
+        try:
+            if self.username:
+                client.username_pw_set(self.username, self.password)
+            client.connect(self.host, self.port, 30)
+            connected = True
+            client.loop_start()
+            loop_started = True
+            for message in messages:
+                payload = message["payload"]
+                body = payload if isinstance(payload, str) else json.dumps(payload)
+                receipt = client.publish(
+                    message["topic"],
+                    body,
+                    qos=int(message.get("qos", self.qos)),
+                    retain=bool(message.get("retain")),
+                )
+                receipt.wait_for_publish(timeout=self.publish_timeout)
+                published += 1
+            return {
+                "ok": True,
+                "dry_run": False,
+                "broker": f"{self.host}:{self.port}",
+                "published": published,
+                "qos": self.qos,
+            }
+        except Exception as exc:
+            return {
+                "ok": False,
+                "dry_run": False,
+                "broker": f"{self.host}:{self.port}",
+                "published": published,
+                "error": f"MQTT publish failed: {exc}",
+            }
+        finally:
+            if connected:
+                client.disconnect()
+            if loop_started:
+                client.loop_stop()
+
+    def _new_client(self) -> MqttClient:
+        if self.client_factory is not None:
+            return self.client_factory()
+        try:
+            import paho.mqtt.client as mqtt
+        except ImportError as exc:
+            raise RuntimeError(
+                'paho-mqtt not installed; pip install -e ".[mqtt]" or use dry_run'
+            ) from exc
+        return mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)

--- a/packages/bridge/tests/test_mqtt_live.py
+++ b/packages/bridge/tests/test_mqtt_live.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from hiri_bridge.adapters.mqtt_pub import MqttDiscoveryPublisher
+from hiri_bridge.devices.types import Device
+
+
+class FakePublishReceipt:
+    def __init__(self, calls: list[tuple[Any, ...]]):
+        self.calls = calls
+
+    def wait_for_publish(self, timeout: float | None = None) -> None:
+        self.calls.append(("wait_for_publish", timeout))
+
+
+class FakeMqttClient:
+    def __init__(self):
+        self.calls: list[tuple[Any, ...]] = []
+
+    def username_pw_set(self, username: str, password: str) -> None:
+        self.calls.append(("username_pw_set", username, password))
+
+    def connect(self, host: str, port: int, keepalive: int) -> None:
+        self.calls.append(("connect", host, port, keepalive))
+
+    def loop_start(self) -> None:
+        self.calls.append(("loop_start",))
+
+    def publish(
+        self, topic: str, payload: str, qos: int = 0, retain: bool = False
+    ) -> FakePublishReceipt:
+        self.calls.append(("publish", topic, payload, qos, retain))
+        return FakePublishReceipt(self.calls)
+
+    def disconnect(self) -> None:
+        self.calls.append(("disconnect",))
+
+    def loop_stop(self) -> None:
+        self.calls.append(("loop_stop",))
+
+
+class FailingPublishReceipt(FakePublishReceipt):
+    def wait_for_publish(self, timeout: float | None = None) -> None:
+        self.calls.append(("wait_for_publish", timeout))
+        raise TimeoutError("broker acknowledgement timed out")
+
+
+class FailingMqttClient(FakeMqttClient):
+    def publish(
+        self, topic: str, payload: str, qos: int = 0, retain: bool = False
+    ) -> FakePublishReceipt:
+        self.calls.append(("publish", topic, payload, qos, retain))
+        return FailingPublishReceipt(self.calls)
+
+
+def test_live_publish_uses_network_loop_and_waits_for_delivery() -> None:
+    client = FakeMqttClient()
+    publisher = MqttDiscoveryPublisher(
+        host="broker.test",
+        port=1884,
+        username="hiri",
+        password="secret",
+        client_factory=lambda: client,
+        publish_timeout=2.5,
+    )
+    device = Device(
+        id="light.test",
+        name="Test light",
+        domain="light",
+        state={"state": "on"},
+    )
+
+    result = publisher.publish([device], dry_run=False)
+
+    assert result == {
+        "ok": True,
+        "dry_run": False,
+        "broker": "broker.test:1884",
+        "published": 3,
+        "qos": 1,
+    }
+    assert client.calls[:3] == [
+        ("username_pw_set", "hiri", "secret"),
+        ("connect", "broker.test", 1884, 30),
+        ("loop_start",),
+    ]
+    published = [call for call in client.calls if call[0] == "publish"]
+    assert [call[1] for call in published] == [
+        "homeassistant/light/hiri/light_test/config",
+        "hiri/state/light/test",
+        "hiri/status",
+    ]
+    assert all(call[3:] == (1, True) for call in published)
+    assert json.loads(published[0][2])["unique_id"] == "hiri_light_test"
+    assert [call for call in client.calls if call[0] == "wait_for_publish"] == [
+        ("wait_for_publish", 2.5),
+        ("wait_for_publish", 2.5),
+        ("wait_for_publish", 2.5),
+    ]
+    assert client.calls[-2:] == [("disconnect",), ("loop_stop",)]
+
+
+def test_live_publish_reports_failure_and_closes_client() -> None:
+    client = FailingMqttClient()
+    publisher = MqttDiscoveryPublisher(client_factory=lambda: client)
+    device = Device(id="switch.test", name="Test switch", domain="switch")
+
+    result = publisher.publish([device], dry_run=False)
+
+    assert result["ok"] is False
+    assert result["published"] == 0
+    assert "broker acknowledgement timed out" in result["error"]
+    assert client.calls[-2:] == [("disconnect",), ("loop_stop",)]


### PR DESCRIPTION
## Summary

- make live MQTT publishing start Paho's network loop and wait for every QoS 1 publish receipt
- support an injected MQTT client so the live path has deterministic offline tests
- return structured failures and always disconnect/stop the client loop
- document a loopback-only Mosquitto Docker Desktop smoke test for Windows

## Why

The live path previously disconnected immediately after queueing messages. Without a running network loop or publish confirmation, the command could report success before the broker received the retained discovery messages. The injected client also lets CI exercise this behavior without network access.

## User impact

`hiri-bridge mqtt publish --live` now waits for broker acknowledgement before reporting each message as published, while dry-run behavior remains unchanged. Local users have a reproducible Mosquitto smoke test that does not expose the development broker to the LAN.

## Validation

- `ruff check src tests`
- `pytest -q --cov=hiri_bridge --cov-fail-under=60` — 101 passed, 65.27% coverage
- `hiri-bridge demo`
- `python -m compileall -q src tests`

Implementation follows the Eclipse Paho guidance for running a network loop and waiting for publish completion:
https://eclipse.dev/paho/files/paho.mqtt.python/html/index.html

The smoke-test broker uses the official Eclipse Mosquitto image and documentation:
https://mosquitto.org/documentation/

Fixes #3
