### PR TITLE
Add live Zigbee2MQTT device import

### DIFF
--- a/docs/zigbee2mqtt-adapter.md
+++ b/docs/zigbee2mqtt-adapter.md
@@ -1,0 +1,35 @@
+# Zigbee2MQTT adapter
+
+HIRI can import the device inventory exposed by the Zigbee2MQTT frontend
+WebSocket API. With no URL configured, the existing offline sample remains the
+default.
+
+## Live import
+
+Install the optional WebSocket dependency from `packages/bridge`:
+
+```powershell
+pip install -e ".[z2m]"
+```
+
+Set the URL of the Zigbee2MQTT frontend and, when frontend authentication is
+enabled, its token:
+
+```powershell
+$env:HIRI_Z2M_URL = "http://127.0.0.1:8080"
+$env:HIRI_Z2M_TOKEN = "replace-with-your-frontend-token"
+hiri-bridge adapters import z2m
+```
+
+The adapter converts `http`/`https` URLs to `ws`/`wss`, connects to `/api`, and
+waits for the retained `bridge/devices` message. Coordinator rows are ignored;
+device capabilities are mapped to HIRI domains such as `light`, `switch`,
+`binary_sensor`, and `sensor`.
+
+Prefer an `https` frontend URL when traffic leaves the local machine so the
+authentication token is protected by TLS.
+
+## References
+
+- [Zigbee2MQTT frontend WebSocket implementation](https://github.com/Koenkk/zigbee2mqtt/blob/master/lib/extension/frontend.ts)
+- [Zigbee2MQTT exposes format](https://www.zigbee2mqtt.io/guide/usage/exposes.html)

--- a/packages/bridge/README.md
+++ b/packages/bridge/README.md
@@ -7,3 +7,6 @@ pip install -e ".[dev,api]"
 hiri-bridge demo
 hiri-bridge serve --port 8780
 ```
+
+For live Zigbee2MQTT device import, see
+[`../../docs/zigbee2mqtt-adapter.md`](../../docs/zigbee2mqtt-adapter.md).

--- a/packages/bridge/pyproject.toml
+++ b/packages/bridge/pyproject.toml
@@ -21,6 +21,7 @@ dev = ["pytest>=8.0", "pytest-cov>=4.0", "ruff>=0.4", "httpx>=0.27"]
 api = ["fastapi>=0.110", "uvicorn>=0.27", "httpx>=0.27"]
 mqtt = ["paho-mqtt>=2.0"]
 ha-ws = ["websockets>=12.0"]
+z2m = ["websockets>=12.0"]
 
 [project.scripts]
 hiri-bridge = "hiri_bridge.cli:app"

--- a/packages/bridge/src/hiri_bridge/adapters/catalog.py
+++ b/packages/bridge/src/hiri_bridge/adapters/catalog.py
@@ -44,10 +44,10 @@ def list_adapters() -> list[dict[str, Any]]:
         },
         {
             "name": "z2m",
-            "kind": "mqtt_http",
+            "kind": "websocket",
             "live": True,
-            "description": "Zigbee2MQTT device import (fixture offline)",
-            "status": "fixture ready",
+            "description": "Zigbee2MQTT WebSocket device import (fixture offline)",
+            "status": Zigbee2MqttAdapter().status(),
         },
         {
             "name": "tuya",

--- a/packages/bridge/src/hiri_bridge/adapters/z2m.py
+++ b/packages/bridge/src/hiri_bridge/adapters/z2m.py
@@ -1,11 +1,20 @@
-"""Zigbee2MQTT adapter — fixture offline; optional live HTTP/MQTT later."""
+"""Zigbee2MQTT device import through the frontend WebSocket API."""
 
 from __future__ import annotations
 
+import json
+import os
+import re
+import time
+from collections.abc import Callable, Iterable, Mapping
+from contextlib import AbstractContextManager
+from typing import Any, Protocol
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
 from hiri_bridge.devices.types import Device
 
-# Minimal offline fixture mimicking z2m /api/devices-ish payload
-Z2M_FIXTURE: list[dict] = [
+# Minimal offline sample shaped like the retained ``bridge/devices`` payload.
+Z2M_FIXTURE: list[dict[str, Any]] = [
     {
         "friendly_name": "kitchen/motion",
         "type": "EndDevice",
@@ -26,49 +35,214 @@ Z2M_FIXTURE: list[dict] = [
     },
 ]
 
+_DOMAIN_BY_EXPOSE_TYPE = {
+    "light": "light",
+    "switch": "switch",
+    "climate": "climate",
+    "cover": "cover",
+    "lock": "lock",
+    "fan": "fan",
+}
+_BINARY_DEVICE_CLASSES = {
+    "contact": "door",
+    "gas": "gas",
+    "motion": "motion",
+    "occupancy": "motion",
+    "presence": "presence",
+    "smoke": "smoke",
+    "tamper": "tamper",
+    "vibration": "vibration",
+    "water_leak": "moisture",
+}
+
+
+class Z2mConnection(Protocol):
+    def recv(self, timeout: float | None = None) -> str | bytes: ...
+
+
+ConnectionFactory = Callable[..., AbstractContextManager[Z2mConnection]]
+
 
 class Zigbee2MqttAdapter:
     name = "z2m"
 
-    def __init__(self, base_url: str = "", use_fixture: bool = True):
-        self.base_url = (base_url or "").rstrip("/")
-        self.use_fixture = use_fixture
+    def __init__(
+        self,
+        base_url: str | None = None,
+        token: str | None = None,
+        use_fixture: bool | None = None,
+        *,
+        timeout: float = 5.0,
+        connection_factory: ConnectionFactory | None = None,
+    ):
+        configured_url = base_url if base_url is not None else os.environ.get("HIRI_Z2M_URL", "")
+        self.base_url = configured_url.rstrip("/")
+        self.token = token if token is not None else os.environ.get("HIRI_Z2M_TOKEN", "")
+        self.use_fixture = not self.base_url if use_fixture is None else use_fixture
+        self.timeout = timeout
+        self.connection_factory = connection_factory
+
+    def status(self) -> str:
+        if self.use_fixture:
+            return "fixture ready"
+        if not self.base_url:
+            return "HIRI_Z2M_URL required for live import"
+        if self.connection_factory is not None:
+            return f"configured -> {_display_host(self.base_url)}"
+        try:
+            import websockets.sync.client  # noqa: F401
+        except ImportError:
+            return 'configured (pip install -e ".[z2m]" for live import)'
+        return f"configured -> {_display_host(self.base_url)}"
+
+    @property
+    def websocket_url(self) -> str:
+        if not self.base_url:
+            raise ValueError("HIRI_Z2M_URL is required for live import")
+
+        parsed = urlsplit(self.base_url)
+        if parsed.scheme in {"http", "ws"}:
+            scheme = "ws"
+        elif parsed.scheme in {"https", "wss"}:
+            scheme = "wss"
+        else:
+            raise ValueError("Zigbee2MQTT URL must use http, https, ws, or wss")
+
+        path = parsed.path.rstrip("/")
+        if not path.endswith("/api"):
+            path = f"{path}/api"
+        query = parse_qsl(parsed.query, keep_blank_values=True)
+        if self.token:
+            query = [(key, value) for key, value in query if key != "token"]
+            query.append(("token", self.token))
+        return urlunsplit((scheme, parsed.netloc, path, urlencode(query), ""))
 
     def list_remote(self) -> list[Device]:
-        if self.base_url and not self.use_fixture:
-            # Live HTTP to z2m frontend API would go here
+        if self.use_fixture:
+            return devices_from_payload(Z2M_FIXTURE)
+        if not self.base_url:
             return []
-        devices: list[Device] = []
-        for row in Z2M_FIXTURE:
-            name = row["friendly_name"]
-            exposes = row.get("exposes") or []
-            domain = "sensor"
-            if any(e.get("type") == "light" for e in exposes):
-                domain = "light"
-            elif any(e.get("name") in {"occupancy", "contact", "motion"} for e in exposes):
-                domain = "binary_sensor"
-            slug = name.replace("/", "_").replace(" ", "_").lower()
-            devices.append(
-                Device(
-                    id=f"{domain}.z2m_{slug}",
-                    name=name,
-                    domain=domain,
-                    manufacturer=(row.get("definition") or {}).get("vendor", "Zigbee"),
-                    model=(row.get("definition") or {}).get("model", "z2m"),
-                    area=name.split("/")[0] if "/" in name else "home",
-                    state={"state": "off" if domain != "sensor" else "0"},
-                    attributes={
-                        "via": "z2m",
-                        "device_class": "motion"
-                        if "motion" in name or "occupancy" in str(exposes)
-                        else "door"
-                        if "contact" in name
-                        else None,
-                    },
-                    adapter="z2m",
-                )
-            )
-        return devices
+        try:
+            return devices_from_payload(self._read_live_payload())
+        except Exception:
+            return []
 
     def push_state(self, device: Device) -> None:
         return None
+
+    def _read_live_payload(self) -> list[Mapping[str, Any]]:
+        factory = self.connection_factory
+        if factory is None:
+            try:
+                from websockets.sync.client import connect
+            except ImportError as exc:
+                raise RuntimeError(
+                    'websockets not installed; pip install -e ".[z2m]"'
+                ) from exc
+            factory = connect
+
+        deadline = time.monotonic() + self.timeout
+        with factory(
+            self.websocket_url,
+            open_timeout=self.timeout,
+            close_timeout=self.timeout,
+        ) as connection:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError("timed out waiting for Zigbee2MQTT bridge/devices")
+                raw = connection.recv(timeout=remaining)
+                message = json.loads(raw)
+                if not isinstance(message, dict) or message.get("topic") != "bridge/devices":
+                    continue
+                payload = message.get("payload")
+                if isinstance(payload, str):
+                    payload = json.loads(payload)
+                if not isinstance(payload, list):
+                    raise ValueError("Zigbee2MQTT bridge/devices payload must be a list")
+                return payload
+
+
+def devices_from_payload(rows: Iterable[Mapping[str, Any]]) -> list[Device]:
+    devices: list[Device] = []
+    for row in rows:
+        if str(row.get("type", "")).lower() == "coordinator":
+            continue
+
+        friendly_name = str(row.get("friendly_name") or row.get("ieee_address") or "").strip()
+        if not friendly_name:
+            continue
+
+        exposes = row.get("exposes")
+        if not isinstance(exposes, list):
+            exposes = []
+        domain, device_class = _classify_exposes(exposes)
+        definition = row.get("definition")
+        if not isinstance(definition, Mapping):
+            definition = {}
+
+        attributes: dict[str, Any] = {
+            "via": "z2m",
+            "zigbee_type": row.get("type"),
+            "ieee_address": row.get("ieee_address"),
+            "power_source": row.get("power_source"),
+            "supported": row.get("supported", True),
+        }
+        if device_class:
+            attributes["device_class"] = device_class
+        attributes = {key: value for key, value in attributes.items() if value is not None}
+
+        devices.append(
+            Device(
+                id=f"{domain}.z2m_{_slug(friendly_name)}",
+                name=friendly_name,
+                domain=domain,
+                manufacturer=str(definition.get("vendor") or "Zigbee"),
+                model=str(definition.get("model") or row.get("model_id") or "z2m"),
+                area=friendly_name.split("/", 1)[0] if "/" in friendly_name else "home",
+                online=bool(row.get("interview_completed", True))
+                and not bool(row.get("disabled", False)),
+                state={"state": "unknown"},
+                attributes=attributes,
+                adapter="z2m",
+            )
+        )
+    return devices
+
+
+def _classify_exposes(exposes: Iterable[Mapping[str, Any]]) -> tuple[str, str | None]:
+    flattened = list(_flatten_exposes(exposes))
+    expose_types = {str(expose.get("type", "")).lower() for expose in flattened}
+    for expose_type, domain in _DOMAIN_BY_EXPOSE_TYPE.items():
+        if expose_type in expose_types:
+            return domain, None
+
+    expose_names = {
+        str(expose.get("name") or expose.get("property") or "").lower()
+        for expose in flattened
+    }
+    for name, device_class in _BINARY_DEVICE_CLASSES.items():
+        if name in expose_names:
+            return "binary_sensor", device_class
+    if "binary" in expose_types:
+        return "binary_sensor", None
+    return "sensor", None
+
+
+def _flatten_exposes(exposes: Iterable[Mapping[str, Any]]) -> Iterable[Mapping[str, Any]]:
+    for expose in exposes:
+        if not isinstance(expose, Mapping):
+            continue
+        yield expose
+        features = expose.get("features")
+        if isinstance(features, list):
+            yield from _flatten_exposes(features)
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"_+", "_", re.sub(r"[^\w]+", "_", value.lower())).strip("_") or "device"
+
+
+def _display_host(url: str) -> str:
+    parsed = urlsplit(url)
+    return parsed.netloc or parsed.path.split("/", 1)[0]

--- a/packages/bridge/tests/fixtures/z2m_devices.json
+++ b/packages/bridge/tests/fixtures/z2m_devices.json
@@ -1,0 +1,71 @@
+[
+  {
+    "ieee_address": "0x00124b0024c00001",
+    "type": "Coordinator",
+    "network_address": 0,
+    "supported": false,
+    "friendly_name": "Coordinator"
+  },
+  {
+    "ieee_address": "0x00124b0024c00002",
+    "type": "Router",
+    "network_address": 1111,
+    "supported": true,
+    "friendly_name": "living/main bulb",
+    "interview_completed": true,
+    "disabled": false,
+    "power_source": "Mains (single phase)",
+    "definition": {
+      "model": "LED1623G12",
+      "vendor": "IKEA",
+      "description": "TRADFRI bulb"
+    },
+    "exposes": [
+      {
+        "type": "light",
+        "features": [
+          {"type": "binary", "name": "state", "property": "state"},
+          {"type": "numeric", "name": "brightness", "property": "brightness"}
+        ]
+      }
+    ]
+  },
+  {
+    "ieee_address": "0x00158d0000000003",
+    "type": "EndDevice",
+    "network_address": 2222,
+    "supported": true,
+    "friendly_name": "hall/front contact",
+    "interview_completed": true,
+    "disabled": false,
+    "power_source": "Battery",
+    "definition": {
+      "model": "MCCGQ11LM",
+      "vendor": "Xiaomi",
+      "description": "Door sensor"
+    },
+    "exposes": [
+      {"type": "binary", "name": "contact", "property": "contact"},
+      {"type": "numeric", "name": "battery", "property": "battery"}
+    ]
+  },
+  {
+    "ieee_address": "0x00158d0000000004",
+    "type": "EndDevice",
+    "network_address": 3333,
+    "supported": true,
+    "friendly_name": "bedroom/temperature",
+    "interview_completed": false,
+    "disabled": false,
+    "power_source": "Battery",
+    "definition": {
+      "model": "WSDCGQ11LM",
+      "vendor": "Xiaomi",
+      "description": "Temperature and humidity sensor"
+    },
+    "exposes": [
+      {"type": "numeric", "name": "temperature", "property": "temperature"},
+      {"type": "numeric", "name": "humidity", "property": "humidity"}
+    ]
+  }
+]

--- a/packages/bridge/tests/test_z2m_live.py
+++ b/packages/bridge/tests/test_z2m_live.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from hiri_bridge.adapters.z2m import Zigbee2MqttAdapter, devices_from_payload
+
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "z2m_devices.json"
+
+
+class FakeConnection:
+    def __init__(self, messages: list[dict[str, Any]]):
+        self.messages = iter(messages)
+        self.timeouts: list[float | None] = []
+        self.closed = False
+
+    def __enter__(self) -> FakeConnection:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.closed = True
+
+    def recv(self, timeout: float | None = None) -> str:
+        self.timeouts.append(timeout)
+        return json.dumps(next(self.messages))
+
+
+def load_fixture() -> list[dict[str, Any]]:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def test_fixture_maps_z2m_inventory_to_hiri_devices() -> None:
+    devices = devices_from_payload(load_fixture())
+
+    assert [device.id for device in devices] == [
+        "light.z2m_living_main_bulb",
+        "binary_sensor.z2m_hall_front_contact",
+        "sensor.z2m_bedroom_temperature",
+    ]
+    light, contact, temperature = devices
+    assert light.model == "LED1623G12"
+    assert light.manufacturer == "IKEA"
+    assert light.area == "living"
+    assert light.attributes["ieee_address"] == "0x00124b0024c00002"
+    assert contact.attributes["device_class"] == "door"
+    assert contact.adapter == "z2m"
+    assert temperature.online is False
+
+
+def test_live_import_reads_retained_bridge_devices_message(monkeypatch: Any) -> None:
+    fixture = load_fixture()
+    connection = FakeConnection(
+        [
+            {"topic": "bridge/state", "payload": {"state": "online"}},
+            {"topic": "bridge/devices", "payload": fixture},
+        ]
+    )
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def connection_factory(url: str, **kwargs: Any) -> FakeConnection:
+        calls.append((url, kwargs))
+        return connection
+
+    monkeypatch.setenv("HIRI_Z2M_URL", "https://z2m.example/panel?source=hiri")
+    monkeypatch.setenv("HIRI_Z2M_TOKEN", "token with spaces")
+    adapter = Zigbee2MqttAdapter(
+        timeout=2.0,
+        connection_factory=connection_factory,
+    )
+
+    devices = adapter.list_remote()
+
+    assert len(devices) == 3
+    assert calls == [
+        (
+            "wss://z2m.example/panel/api?source=hiri&token=token+with+spaces",
+            {"open_timeout": 2.0, "close_timeout": 2.0},
+        )
+    ]
+    assert len(connection.timeouts) == 2
+    assert all(timeout is not None and 0 < timeout <= 2.0 for timeout in connection.timeouts)
+    assert connection.closed is True
+
+
+def test_live_import_is_offline_safe_on_invalid_payload() -> None:
+    connection = FakeConnection(
+        [{"topic": "bridge/devices", "payload": {"unexpected": "object"}}]
+    )
+    adapter = Zigbee2MqttAdapter(
+        base_url="ws://127.0.0.1:8080/api",
+        use_fixture=False,
+        connection_factory=lambda *_args, **_kwargs: connection,
+    )
+
+    assert adapter.list_remote() == []
+    assert connection.closed is True
+
+
+def test_fixture_remains_default_without_live_url(monkeypatch: Any) -> None:
+    monkeypatch.delenv("HIRI_Z2M_URL", raising=False)
+    adapter = Zigbee2MqttAdapter()
+
+    assert adapter.status() == "fixture ready"
+    assert len(adapter.list_remote()) == 3


### PR DESCRIPTION
## Summary

- replace the Zigbee2MQTT live-import placeholder with the frontend WebSocket `/api` path
- wait for the retained `bridge/devices` inventory and map its exposes to HIRI domains
- preserve the existing offline fixture when no live URL is configured
- support frontend token authentication without logging or storing the token
- add a representative JSON fixture, mocked live-connection tests, and setup documentation

## Why

The existing adapter returned an empty list whenever live mode was requested. Zigbee2MQTT exposes its retained MQTT inventory to frontend WebSocket clients, so HIRI can import real devices without requiring direct broker access.

## User impact

Users can set `HIRI_Z2M_URL` and optionally `HIRI_Z2M_TOKEN`, install the `z2m` extra, and run the existing `hiri-bridge adapters import z2m` command. With no URL configured, the command remains offline-safe and imports the bundled sample.

Coordinator rows are ignored. Lights, switches, binary sensors, and general sensors are classified from the recursive `exposes` structure, while manufacturer, model, area, power source, IEEE address, and interview status are retained.

## Validation

- `ruff check src tests`
- `pytest -q --cov=hiri_bridge --cov-fail-under=60` — 103 passed, 64.84% coverage
- `python -m hiri_bridge.cli demo`
- `python -m compileall -q src tests`
- verified the implementation against `websockets` 16.1.1 client and receive signatures

Protocol references:

- https://github.com/Koenkk/zigbee2mqtt/blob/master/lib/extension/frontend.ts
- https://www.zigbee2mqtt.io/guide/usage/exposes.html

Claim: https://github.com/mergeos-bounties/HIRI/issues/4#issuecomment-5060586303

Fixes #4
