### PR TITLE
feat(bridge): Matter adapter scaffold + docs/MATTER.md (fixes #7)

### DIFF
--- a/docs/MATTER.md
+++ b/docs/MATTER.md
@@ -1,0 +1,97 @@
+# Matter on HIRI — direction and scaffold
+
+Status: **scaffold**. The mapping and the device shape are implemented and tested
+offline (`packages/bridge/src/hiri_bridge/adapters/matter.py`); commissioning and live
+subscriptions are not, and say so instead of failing quietly.
+
+## Why HIRI wants Matter
+
+Every other adapter in the bridge speaks one vendor's dialect: Zigbee2MQTT talks z2m
+JSON, Tuya talks category codes, HA talks entity ids. Matter is the one protocol where
+the device itself declares what it is, in a way that is the same across vendors. For HIRI
+that means the mapping layer — the thing that is fragile in every other adapter — becomes
+a lookup table published in a spec, which is exactly the piece this scaffold implements.
+
+Two roles are possible, and they are not the same job:
+
+| Role | What it means | Where HIRI sits |
+| --- | --- | --- |
+| Matter **controller** | HIRI commissions nodes onto its own fabric and drives them | the direction below |
+| Matter **bridge** (Bridged Node) | HIRI exposes its non-Matter devices *to* Apple/Google/Alexa | later, needs a certified stack |
+
+Being a controller first is the cheaper half: it makes Matter devices appear in the HIRI
+registry next to z2m and Tuya ones, and it reuses the HA MQTT discovery path that already
+exists. Being a bridge means shipping a commissionable Matter device, which drags in
+certification, attestation certificates and a Thread/Wi-Fi provisioning story. Not now.
+
+## What the scaffold does today
+
+* `MATTER_DEVICE_TYPE_MAP` — endpoint device type → HIRI domain, straight from the Matter
+  1.x Device Library:
+
+  | Device type | Name | HIRI domain |
+  | --- | --- | --- |
+  | `0x0100` / `0x0101` / `0x010C` / `0x010D` | On/Off, Dimmable, Color Temperature, Extended Color Light | `light` |
+  | `0x010A` / `0x010B` / `0x0103` | On/Off & Dimmable Plug-in Unit, On/Off Light Switch | `switch` |
+  | `0x000A` | Door Lock | `lock` |
+  | `0x0202` | Window Covering | `cover` |
+  | `0x0301` | Thermostat | `climate` |
+  | `0x002B` | Fan | `fan` |
+  | `0x0015` / `0x0107` / `0x0076` | Contact, Occupancy, Smoke CO Alarm | `binary_sensor` |
+  | `0x0302` / `0x0305` / `0x0306` / `0x0307` / `0x0106` | Temperature, Pressure, Flow, Humidity, Light Sensor | `sensor` |
+
+* `MATTER_UTILITY_DEVICE_TYPES` — Root Node `0x0016`, Aggregator `0x000E`, Bridged Node
+  `0x0013`, Power Source `0x0011`, OTA `0x0012`/`0x0014`. An endpoint that carries only
+  these is *not* a device; endpoint 0 of every node is skipped for this reason.
+* Unknown device types still produce a device, in the `sensor` fallback domain, tagged
+  `device_type: 0xFFF1` — a new gadget shows up in the registry instead of disappearing.
+* One HIRI device per **(node, endpoint)** pair, id `<domain>.matter_<node>_<endpoint>`.
+  A Matter node is not one device: a sensor hub reports contact on endpoint 2 and
+  temperature on endpoint 3, and both must land separately.
+* Attributes keep the identity a controller would need later: `node_id`, `endpoint_id`,
+  `fabric_id`, `vendor_id`, `product_id`, `serial_number`, `bridged`.
+
+```bash
+hiri-bridge adapters list                # matter: scaffold ready (fixture)
+hiri-bridge adapters import matter       # 5 devices from 4 fixture nodes
+```
+
+## Making it live
+
+The intended controller is **python-matter-server** (the same one Home Assistant uses):
+it runs the CHIP SDK in its own container and exposes a WebSocket API, which keeps the
+SDK's native build out of the bridge package. The alternative — linking `chip-repl`
+directly — pulls a large native toolchain into HIRI's install and is not worth it.
+
+1. Run the controller next to the bridge:
+   ```bash
+   docker run -d --name matter-server --network=host \
+     -v $(pwd)/matter-data:/data ghcr.io/home-assistant-libs/python-matter-server:stable
+   ```
+   Host networking is not optional — commissioning needs mDNS and IPv6 on the LAN.
+2. Point the adapter at it and turn the fixture off:
+   ```python
+   MatterAdapter(server_url="ws://127.0.0.1:5580/ws", use_fixture=False)
+   ```
+3. Implement `list_remote()` over the WebSocket API: `start_listening` returns all
+   commissioned nodes; each node carries `attributes` keyed `"<endpoint>/<cluster>/<attr>"`.
+   Device types come from the Descriptor cluster (`0x001D`) attribute `DeviceTypeList`,
+   which is what `domain_for_device_types()` already consumes.
+4. Commissioning (`commission()`): `commission_with_code` with the 11-digit manual code or
+   the QR payload. This is the security-sensitive part — PASE with the setup passcode,
+   then CASE on operational credentials, and the node joins **HIRI's fabric**. Store the
+   returned node id; the fabric's operational credentials live in the controller's data
+   volume and must be backed up with it, or every device has to be re-paired.
+5. State follow: subscribe rather than poll — the controller pushes attribute updates, and
+   they map onto the existing registry `upsert` + MQTT discovery publish path.
+6. Writes (`push_state()`): cluster commands (On/Off `0x0006`, Level Control `0x0008`,
+   Color Control `0x0300`) per endpoint. Keep them behind the same allowlist the other
+   adapters use before anything can drive a lock.
+
+## Testing approach
+
+`packages/bridge/tests/test_matter_adapter.py` covers the mapping table, utility-endpoint
+skipping, the unknown-type fallback, id uniqueness, bridged flagging, offline nodes, the
+registry import, and that both live paths import nothing while reporting *why*. All of it
+runs with no fabric, no SDK and no network. When the WebSocket client lands, the fixture
+becomes a recorded `start_listening` payload and the same assertions keep working.

--- a/packages/bridge/src/hiri_bridge/adapters/catalog.py
+++ b/packages/bridge/src/hiri_bridge/adapters/catalog.py
@@ -7,6 +7,7 @@ from typing import Any
 from hiri_bridge.adapters.ha_rest import HomeAssistantRestAdapter
 from hiri_bridge.adapters.ha_ws import HomeAssistantWebSocketAdapter
 from hiri_bridge.adapters.local import LocalAdapter
+from hiri_bridge.adapters.matter import MatterAdapter
 from hiri_bridge.adapters.mqtt_pub import MqttDiscoveryPublisher
 from hiri_bridge.adapters.tuya import TuyaAdapter
 from hiri_bridge.adapters.z2m import Zigbee2MqttAdapter
@@ -60,8 +61,8 @@ def list_adapters() -> list[dict[str, Any]]:
             "name": "matter",
             "kind": "scaffold",
             "live": False,
-            "description": "Matter bridge (scaffold only)",
-            "status": "planned",
+            "description": "Matter device-type mapping + fixture import (no controller yet)",
+            "status": MatterAdapter().status(),
         },
     ]
     return rows
@@ -75,6 +76,8 @@ def import_from_adapter(name: str) -> list:
         return Zigbee2MqttAdapter().list_remote()
     if key == "tuya":
         return TuyaAdapter().list_remote()
+    if key == "matter":
+        return MatterAdapter().list_remote()
     if key in {"ha_rest", "ha"}:
         return HomeAssistantRestAdapter().list_remote()
     if key in {"ha_ws", "ha_websocket"}:

--- a/packages/bridge/src/hiri_bridge/adapters/matter.py
+++ b/packages/bridge/src/hiri_bridge/adapters/matter.py
@@ -1,0 +1,269 @@
+"""Matter adapter scaffold — offline device-type mapping, no controller yet.
+
+The catalog has advertised a `matter` adapter as "planned" since the adapters package
+was introduced, but there was no module behind it, so `import_from_adapter("matter")`
+raised. This scaffold fills that seam: the part of Matter that HIRI actually needs to
+own — the device type → HIRI domain mapping and the shape of a commissioned node — is
+implemented and tested offline, while the parts that need a real fabric (commissioning,
+subscriptions, writes) are explicit, documented no-ops instead of silent failures.
+
+See docs/MATTER.md for the direction and the steps to make this live.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hiri_bridge.devices.types import Device
+
+# Matter device type IDs (Matter 1.x Device Library) → HIRI/HA domain.
+# Keys are the numeric device type of an *endpoint*, which is what a controller reports.
+MATTER_DEVICE_TYPE_MAP: dict[int, str] = {
+    0x0100: "light",  # On/Off Light
+    0x0101: "light",  # Dimmable Light
+    0x010C: "light",  # Color Temperature Light
+    0x010D: "light",  # Extended Color Light
+    0x010A: "switch",  # On/Off Plug-in Unit
+    0x010B: "switch",  # Dimmable Plug-in Unit
+    0x0103: "switch",  # On/Off Light Switch
+    0x000A: "lock",  # Door Lock
+    0x0202: "cover",  # Window Covering
+    0x0301: "climate",  # Thermostat
+    0x002B: "fan",  # Fan
+    0x0015: "binary_sensor",  # Contact Sensor
+    0x0107: "binary_sensor",  # Occupancy Sensor
+    0x0076: "binary_sensor",  # Smoke CO Alarm
+    0x0302: "sensor",  # Temperature Sensor
+    0x0305: "sensor",  # Pressure Sensor
+    0x0306: "sensor",  # Flow Sensor
+    0x0307: "sensor",  # Humidity Sensor
+    0x0106: "sensor",  # Light Sensor
+}
+
+# Endpoint device types that describe the node itself rather than a controllable thing.
+MATTER_UTILITY_DEVICE_TYPES: frozenset[int] = frozenset(
+    {
+        0x0016,  # Root Node
+        0x000E,  # Aggregator
+        0x0013,  # Bridged Node
+        0x0011,  # Power Source
+        0x0012,  # OTA Requestor
+        0x0014,  # OTA Provider
+    }
+)
+
+MATTER_DEVICE_TYPE_NAMES: dict[int, str] = {
+    0x0100: "On/Off Light",
+    0x0101: "Dimmable Light",
+    0x010C: "Color Temperature Light",
+    0x010D: "Extended Color Light",
+    0x010A: "On/Off Plug-in Unit",
+    0x010B: "Dimmable Plug-in Unit",
+    0x0103: "On/Off Light Switch",
+    0x000A: "Door Lock",
+    0x0202: "Window Covering",
+    0x0301: "Thermostat",
+    0x002B: "Fan",
+    0x0015: "Contact Sensor",
+    0x0107: "Occupancy Sensor",
+    0x0076: "Smoke CO Alarm",
+    0x0302: "Temperature Sensor",
+    0x0305: "Pressure Sensor",
+    0x0306: "Flow Sensor",
+    0x0307: "Humidity Sensor",
+    0x0106: "Light Sensor",
+    0x0016: "Root Node",
+    0x000E: "Aggregator",
+    0x0013: "Bridged Node",
+    0x0011: "Power Source",
+    0x0012: "OTA Requestor",
+    0x0014: "OTA Provider",
+}
+
+# Offline fixture shaped like what python-matter-server reports per commissioned node:
+# a node id, basic information (vendor/product/serial) and endpoints carrying device types.
+MATTER_FIXTURE: list[dict[str, Any]] = [
+    {
+        "node_id": 4,
+        "available": True,
+        "vendor_id": 0x1349,
+        "product_id": 0x0002,
+        "vendor_name": "Apple",
+        "product_name": "Matter Bulb",
+        "serial_number": "MTR-0004",
+        "area": "living",
+        "endpoints": [
+            {"endpoint_id": 0, "device_types": [0x0016]},
+            {"endpoint_id": 1, "device_types": [0x010D], "name": "Living lamp"},
+        ],
+    },
+    {
+        "node_id": 7,
+        "available": True,
+        "vendor_id": 0x1217,
+        "product_id": 0x1001,
+        "vendor_name": "Eve",
+        "product_name": "Eve Energy",
+        "serial_number": "MTR-0007",
+        "area": "kitchen",
+        "endpoints": [
+            {"endpoint_id": 0, "device_types": [0x0016]},
+            {"endpoint_id": 1, "device_types": [0x010A], "name": "Kettle plug"},
+        ],
+    },
+    {
+        "node_id": 11,
+        "available": True,
+        "vendor_id": 0x130A,
+        "product_id": 0x0056,
+        "vendor_name": "Aqara",
+        "product_name": "Matter Sensor Hub",
+        "serial_number": "MTR-0011",
+        "area": "hall",
+        "endpoints": [
+            {"endpoint_id": 0, "device_types": [0x0016, 0x000E]},
+            {"endpoint_id": 2, "device_types": [0x0013, 0x0015], "name": "Front door"},
+            {"endpoint_id": 3, "device_types": [0x0013, 0x0302], "name": "Hall temperature"},
+        ],
+    },
+    {
+        "node_id": 19,
+        "available": False,
+        "vendor_id": 0x1209,
+        "product_id": 0x8005,
+        "vendor_name": "Generic",
+        "product_name": "Unknown gadget",
+        "serial_number": "MTR-0019",
+        "area": "garage",
+        "endpoints": [
+            {"endpoint_id": 0, "device_types": [0x0016]},
+            {"endpoint_id": 1, "device_types": [0xFFF1], "name": "Vendor thing"},
+        ],
+    },
+]
+
+DEFAULT_DOMAIN = "sensor"
+
+
+def domain_for_device_types(device_types: list[int] | tuple[int, ...]) -> str | None:
+    """Pick the HIRI domain for an endpoint from its Matter device types.
+
+    Utility types (Root Node, Bridged Node, Aggregator, …) never produce a device on
+    their own — an endpoint that carries nothing else is skipped. An endpoint with a
+    device type we do not know yet still becomes a device, in the fallback domain, so a
+    new gadget shows up in the registry instead of disappearing silently.
+    """
+    controllable = [dt for dt in device_types if dt not in MATTER_UTILITY_DEVICE_TYPES]
+    if not controllable:
+        return None
+    for dt in controllable:
+        if dt in MATTER_DEVICE_TYPE_MAP:
+            return MATTER_DEVICE_TYPE_MAP[dt]
+    return DEFAULT_DOMAIN
+
+
+def device_type_name(device_type: int) -> str:
+    return MATTER_DEVICE_TYPE_NAMES.get(device_type, f"Unknown (0x{device_type:04X})")
+
+
+class MatterAdapter:
+    """Read-only Matter scaffold.
+
+    `use_fixture=True` (the default) walks the bundled fixture so the mapping, the entity
+    ids and the registry import are exercised with no fabric, no SDK and no network. A
+    real controller is only used when `server_url` is set *and* `use_fixture=False`; that
+    path is not implemented yet and returns nothing rather than pretending.
+    """
+
+    name = "matter"
+
+    def __init__(self, server_url: str = "", fabric_id: int = 1, use_fixture: bool = True):
+        self.server_url = (server_url or "").rstrip("/")
+        self.fabric_id = int(fabric_id)
+        self.use_fixture = use_fixture
+
+    def status(self) -> str:
+        if self.use_fixture:
+            return "scaffold ready (fixture)"
+        if not self.server_url:
+            return "controller not configured (set server_url)"
+        return "controller configured, live path not implemented"
+
+    def list_remote(self) -> list[Device]:
+        if not self.use_fixture:
+            # Live path: a python-matter-server websocket client would fill this in.
+            # See docs/MATTER.md — until then we import nothing rather than guessing.
+            return []
+        devices: list[Device] = []
+        for node in MATTER_FIXTURE:
+            devices.extend(self._devices_for_node(node))
+        return devices
+
+    def _devices_for_node(self, node: dict[str, Any]) -> list[Device]:
+        node_id = int(node["node_id"])
+        vendor = str(node.get("vendor_name") or "Matter")
+        product = str(node.get("product_name") or "matter node")
+        online = bool(node.get("available", True))
+        out: list[Device] = []
+        for endpoint in node.get("endpoints") or []:
+            device_types = [int(dt) for dt in endpoint.get("device_types") or []]
+            domain = domain_for_device_types(device_types)
+            if domain is None:
+                continue  # root/bridged/aggregator endpoint — nothing controllable on it
+            endpoint_id = int(endpoint.get("endpoint_id", 0))
+            primary = next(
+                (dt for dt in device_types if dt not in MATTER_UTILITY_DEVICE_TYPES),
+                device_types[0] if device_types else 0,
+            )
+            label = str(endpoint.get("name") or f"{product} {endpoint_id}")
+            out.append(
+                Device(
+                    id=f"{domain}.matter_{node_id}_{endpoint_id}",
+                    name=label,
+                    domain=domain,
+                    manufacturer=vendor,
+                    model=product,
+                    area=str(node.get("area") or "home"),
+                    online=online,
+                    state={"state": "0" if domain == "sensor" else "off"},
+                    attributes={
+                        "via": "matter",
+                        "node_id": node_id,
+                        "endpoint_id": endpoint_id,
+                        "fabric_id": self.fabric_id,
+                        "device_type": f"0x{primary:04X}",
+                        "device_type_name": device_type_name(primary),
+                        "vendor_id": f"0x{int(node.get('vendor_id', 0)):04X}",
+                        "product_id": f"0x{int(node.get('product_id', 0)):04X}",
+                        "serial_number": node.get("serial_number"),
+                        "bridged": 0x0013 in device_types,
+                    },
+                    adapter="matter",
+                )
+            )
+        return out
+
+    def push_state(self, device: Device) -> None:
+        """Writes need a commissioned fabric — intentionally a no-op in the scaffold."""
+
+    def commission(self, setup_code: str = "") -> dict[str, Any]:
+        """Report what commissioning would need instead of half-doing it."""
+        return {
+            "ok": False,
+            "error": "commissioning requires a Matter controller (python-matter-server or chip SDK)",
+            "setup_code_received": bool(setup_code),
+            "next_steps": [
+                "run python-matter-server with a Thread/Wi-Fi capable host",
+                "set HIRI_MATTER_SERVER_URL and construct MatterAdapter(use_fixture=False)",
+                "pair with the 11-digit manual code or the QR payload, then store the node id",
+            ],
+            "docs": "docs/MATTER.md",
+        }
+
+    @staticmethod
+    def mapping_table() -> dict[str, str]:
+        """Human-readable device type → domain table (hex keys, like the spec prints them)."""
+        return {
+            f"0x{dt:04X} {device_type_name(dt)}": domain
+            for dt, domain in MATTER_DEVICE_TYPE_MAP.items()
+        }

--- a/packages/bridge/tests/test_matter_adapter.py
+++ b/packages/bridge/tests/test_matter_adapter.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hiri_bridge.adapters import import_from_adapter, list_adapters
+from hiri_bridge.adapters.matter import (
+    MATTER_DEVICE_TYPE_MAP,
+    MATTER_UTILITY_DEVICE_TYPES,
+    MatterAdapter,
+    domain_for_device_types,
+)
+from hiri_bridge.devices.registry import DeviceRegistry
+from hiri_bridge.devices.types import DOMAINS
+
+
+def test_matter_is_in_the_catalog_and_importable():
+    row = next(r for r in list_adapters() if r["name"] == "matter")
+    assert row["status"] == "scaffold ready (fixture)"
+    # Used to raise ValueError("unknown adapter: matter") — the catalog advertised it
+    # while no module existed.
+    assert len(import_from_adapter("matter")) >= 3
+
+
+def test_fixture_devices_carry_matter_identity():
+    devices = MatterAdapter().list_remote()
+    assert all(d.adapter == "matter" for d in devices)
+    assert all(d.domain in DOMAINS for d in devices)
+    assert len({d.id for d in devices}) == len(devices)  # node+endpoint keeps ids unique
+    lamp = next(d for d in devices if d.id == "light.matter_4_1")
+    assert lamp.attributes["device_type"] == "0x010D"
+    assert lamp.attributes["device_type_name"] == "Extended Color Light"
+    assert lamp.attributes["node_id"] == 4
+    assert lamp.attributes["endpoint_id"] == 1
+    assert lamp.attributes["vendor_id"] == "0x1349"
+    assert lamp.manufacturer == "Apple"
+
+
+def test_device_types_map_to_expected_domains():
+    devices = {d.id: d for d in MatterAdapter().list_remote()}
+    assert devices["switch.matter_7_1"].domain == "switch"  # On/Off Plug-in Unit
+    assert devices["binary_sensor.matter_11_2"].domain == "binary_sensor"  # Contact Sensor
+    assert devices["sensor.matter_11_3"].domain == "sensor"  # Temperature Sensor
+
+
+def test_bridged_endpoints_are_flagged_and_root_endpoints_skipped():
+    devices = MatterAdapter().list_remote()
+    ids = {d.id for d in devices}
+    # endpoint 0 of every node is a Root Node — it is not a device
+    assert not any(i.endswith("_0") for i in ids)
+    hub_contact = next(d for d in devices if d.id == "binary_sensor.matter_11_2")
+    assert hub_contact.attributes["bridged"] is True
+    assert next(d for d in devices if d.id == "light.matter_4_1").attributes["bridged"] is False
+
+
+def test_offline_node_keeps_online_false():
+    garage = next(d for d in MatterAdapter().list_remote() if d.attributes["node_id"] == 19)
+    assert garage.online is False
+
+
+def test_unknown_device_type_falls_back_instead_of_vanishing():
+    garage = next(d for d in MatterAdapter().list_remote() if d.attributes["node_id"] == 19)
+    assert garage.domain == "sensor"
+    assert garage.attributes["device_type"] == "0xFFF1"
+    assert "Unknown" in garage.attributes["device_type_name"]
+
+
+@pytest.mark.parametrize(
+    ("device_types", "expected"),
+    [
+        ([0x0016], None),  # Root Node only
+        ([0x000E], None),  # Aggregator only
+        ([0x0016, 0x0100], "light"),
+        ([0x0013, 0x0301], "climate"),
+        ([0x0202], "cover"),
+        ([0x000A], "lock"),
+        ([0x002B], "fan"),
+        ([0x1234], "sensor"),  # unknown -> fallback
+        ([], None),
+    ],
+)
+def test_domain_for_device_types(device_types, expected):
+    assert domain_for_device_types(device_types) == expected
+
+
+def test_mapping_table_is_consistent():
+    assert set(MATTER_DEVICE_TYPE_MAP).isdisjoint(MATTER_UTILITY_DEVICE_TYPES)
+    assert set(MATTER_DEVICE_TYPE_MAP.values()) <= set(DOMAINS)
+    table = MatterAdapter.mapping_table()
+    assert len(table) == len(MATTER_DEVICE_TYPE_MAP)
+    assert table["0x0100 On/Off Light"] == "light"
+
+
+def test_live_mode_imports_nothing_and_says_why():
+    unconfigured = MatterAdapter(use_fixture=False)
+    assert unconfigured.list_remote() == []
+    assert "not configured" in unconfigured.status()
+    configured = MatterAdapter(server_url="ws://matter:5580/ws", use_fixture=False)
+    assert configured.list_remote() == []
+    assert "not implemented" in configured.status()
+
+
+def test_commission_reports_requirements_instead_of_failing_silently():
+    result = MatterAdapter().commission("34970112332")
+    assert result["ok"] is False
+    assert result["setup_code_received"] is True
+    assert result["next_steps"]
+    assert result["docs"] == "docs/MATTER.md"
+
+
+def test_push_state_is_a_noop_for_now():
+    devices = MatterAdapter().list_remote()
+    assert MatterAdapter().push_state(devices[0]) is None
+
+
+def test_matter_devices_import_into_registry(tmp_path: Path):
+    reg = DeviceRegistry(path=tmp_path / "d.json")
+    reg.seed()
+    before = reg.stats()["total"]
+    for d in import_from_adapter("matter"):
+        reg.upsert(d)
+    after = reg.stats()["total"]
+    assert after > before
+    assert any(d.adapter == "matter" for d in reg.list())
+
+
+def test_matter_docs_exist():
+    docs = Path(__file__).resolve().parents[3] / "docs" / "MATTER.md"
+    assert docs.is_file()
+    body = docs.read_text(encoding="utf-8")
+    assert "python-matter-server" in body
+    assert "0x010D" in body  # the mapping table is documented, not just coded


### PR DESCRIPTION
Fixes #7 — `docs/MATTER.md` + package stub.

The adapter catalog has listed a `matter` adapter as `"planned"` since the adapters package landed, but there was no module behind it, so the entry was a dead end:

```python
>>> from hiri_bridge.adapters import import_from_adapter
>>> import_from_adapter("matter")
ValueError: unknown adapter: matter
```

This PR fills that seam without pretending to be a controller.

## `adapters/matter.py`

The part HIRI actually has to own is the mapping, and unlike z2m or Tuya it is published in a spec — so it is implemented and tested offline:

* **`MATTER_DEVICE_TYPE_MAP`** — Matter 1.x endpoint device type → HIRI domain (`0x0100`/`0x0101`/`0x010C`/`0x010D` → `light`, `0x010A`/`0x010B`/`0x0103` → `switch`, `0x000A` → `lock`, `0x0202` → `cover`, `0x0301` → `climate`, `0x002B` → `fan`, `0x0015`/`0x0107`/`0x0076` → `binary_sensor`, `0x0302`/`0x0305`/`0x0306`/`0x0307`/`0x0106` → `sensor`).
* **Utility endpoints are not devices.** Root Node `0x0016`, Aggregator `0x000E`, Bridged Node `0x0013`, Power Source `0x0011`, OTA `0x0012`/`0x0014`. Endpoint 0 of every node carries only these, so it is skipped rather than imported as a phantom sensor.
* **One device per (node, endpoint)** — `light.matter_4_1`, `sensor.matter_11_3`. A Matter node is not one device: the fixture hub reports a contact sensor on endpoint 2 and a temperature sensor on endpoint 3, and both have to land separately.
* **Unknown device type still lands**, in the `sensor` fallback, tagged `device_type: "0xFFF1"` / `device_type_name: "Unknown (0xFFF1)"`. A gadget the map does not know yet should be visible in the registry, not silently dropped.
* Attributes carry the identity a controller needs later: `node_id`, `endpoint_id`, `fabric_id`, `vendor_id`, `product_id`, `serial_number`, `bridged`. Offline nodes keep `online: False`.
* **The unimplemented parts say so.** `MatterAdapter(use_fixture=False)` imports nothing and `status()` distinguishes "controller not configured" from "controller configured, live path not implemented"; `commission()` returns the requirements (controller, URL, pairing code) instead of a silent failure; `push_state()` is an explicit no-op.

Catalog wiring: `import_from_adapter("matter")` now works and the catalog row reports the live status instead of a hardcoded `"planned"`.

```
$ hiri-bridge adapters import matter
light.matter_4_1          light          Living lamp       Extended Color Light   online
switch.matter_7_1         switch         Kettle plug       On/Off Plug-in Unit    online
binary_sensor.matter_11_2 binary_sensor  Front door        Contact Sensor         online
sensor.matter_11_3        sensor         Hall temperature  Temperature Sensor     online
sensor.matter_19_1        sensor         Vendor thing      Unknown (0xFFF1)       offline
```

## `docs/MATTER.md`

Controller vs bridge (Bridged Node) role and why controller-first is the cheaper half; the full device-type table; the `python-matter-server` path with the docker line (host networking is not optional — commissioning needs mDNS and IPv6); where device types come from on the wire (Descriptor cluster `0x001D`, `DeviceTypeList` — the same list `domain_for_device_types()` already consumes); commissioning security (PASE with the setup passcode, then CASE on operational credentials, node joins HIRI's fabric, back up the controller data volume or re-pair everything); subscribe-don't-poll for state; cluster commands for writes behind the existing allowlist.

## Tests

`packages/bridge/tests/test_matter_adapter.py` — 21 cases: catalog entry resolves, identity attributes, the three domain mappings, root endpoints skipped and bridged endpoints flagged, offline node, unknown-type fallback, `domain_for_device_types` parametrised over utility/known/unknown/empty, mapping-table consistency (no overlap with utility types, every value a real domain), both live paths, `commission()`, `push_state()`, registry import, and that the doc exists and carries the mapping table.

```
pytest -q                                  120 passed   (99 before)
pytest --cov=hiri_bridge --cov-fail-under=60   65.68%
ruff check src tests                       no new findings (matter.py and the new test are clean)
hiri-bridge demo                           OK
```

No existing behaviour changed: the only edit to an existing file is the catalog registration.


Claim comment: https://github.com/mergeos-bounties/HIRI/issues/7#issuecomment-5063369825
