### PR TITLE
feat: add optional API key authentication middleware for admin API [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/hiri/auth.py
+++ b/src/hiri/auth.py
@@ -1,0 +1,74 @@
+"""Optional API key authentication for HIRI admin API.
+
+Usage:
+    from hiri.auth import require_auth, set_api_key
+
+    # Enable auth with env var HIRI_API_KEY
+    set_api_key("my-secret-key")
+    # or let it read from HIRI_API_KEY env var
+
+    # Protect a route
+    @require_auth
+    def my_handler(request):
+        ...
+"""
+
+from __future__ import annotations
+
+import os
+from functools import wraps
+from typing import Any, Callable
+
+_api_key: str | None = None
+
+
+def set_api_key(key: str | None) -> None:
+    """Set the API key for authentication. None disables auth."""
+    global _api_key
+    _api_key = key
+
+
+def get_api_key() -> str | None:
+    """Get the current API key, falling back to environment variable."""
+    global _api_key
+    if _api_key is not None:
+        return _api_key
+    env_key = os.environ.get("HIRI_API_KEY")
+    if env_key:
+        return env_key
+    return None
+
+
+def require_auth(handler: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator that requires a valid API key in the request.
+
+    Usage:
+        @require_auth
+        def my_handler(request):
+            ...
+
+    The request must include an 'Authorization: Bearer <key>' header.
+    If auth is disabled (no key set), all requests pass through.
+    """
+    api_key = get_api_key()
+
+    # If no API key is configured, auth is disabled — pass through
+    if api_key is None:
+        return handler
+
+    @wraps(handler)
+    def wrapper(request: dict[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
+        auth_header = request.get("headers", {}).get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            return {"ok": False, "status": 401, "error": "Missing or invalid Authorization header"}
+        token = auth_header.removeprefix("Bearer ").strip()
+        if token != api_key:
+            return {"ok": False, "status": 403, "error": "Invalid API key"}
+        return handler(request, *args, **kwargs)
+
+    return wrapper
+
+
+def is_auth_enabled() -> bool:
+    """Check if authentication is currently enabled."""
+    return get_api_key() is not None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,71 @@
+"""Tests for HIRI API key authentication middleware."""
+
+from __future__ import annotations
+
+import os
+
+from hiri.auth import is_auth_enabled, require_auth, set_api_key
+
+
+def test_auth_disabled_by_default() -> None:
+    """When no key is set, auth is disabled."""
+    set_api_key(None)
+    assert is_auth_enabled() is False
+
+
+def test_auth_enabled_when_key_set() -> None:
+    """When a key is set, auth is enabled."""
+    set_api_key("test-key-123")
+    assert is_auth_enabled() is True
+
+
+def test_auth_enabled_via_env() -> None:
+    """When HIRI_API_KEY env var is set, auth is enabled."""
+    set_api_key(None)
+    os.environ["HIRI_API_KEY"] = "env-key-456"
+    try:
+        assert is_auth_enabled() is True
+    finally:
+        del os.environ["HIRI_API_KEY"]
+
+
+def test_passes_with_valid_key() -> None:
+    """Request with valid Bearer token passes through."""
+    set_api_key("secret-key")
+    decorated = require_auth(lambda req: {"ok": True, "data": "protected"})
+    result = decorated({"headers": {"Authorization": "Bearer secret-key"}})
+    assert result["ok"] is True
+
+
+def test_rejects_missing_header() -> None:
+    """Request without Authorization header is rejected with 401."""
+    set_api_key("secret-key")
+    decorated = require_auth(lambda req: {"ok": True, "data": "protected"})
+    result = decorated({"headers": {}})
+    assert result["ok"] is False
+    assert result["status"] == 401
+
+
+def test_rejects_wrong_key() -> None:
+    """Request with wrong Bearer token is rejected with 403."""
+    set_api_key("secret-key")
+    decorated = require_auth(lambda req: {"ok": True, "data": "protected"})
+    result = decorated({"headers": {"Authorization": "Bearer wrong-key"}})
+    assert result["ok"] is False
+    assert result["status"] == 403
+
+
+def test_passes_without_auth_when_disabled() -> None:
+    """When auth is disabled, all requests pass through."""
+    set_api_key(None)
+    decorated = require_auth(lambda req: {"ok": True, "data": "public"})
+    result = decorated({"headers": {}})
+    assert result["ok"] is True
+
+
+def test_auth_persists_until_cleared() -> None:
+    """Key persists across calls until set to None."""
+    set_api_key("persist-key")
+    assert is_auth_enabled() is True
+    set_api_key(None)
+    assert is_auth_enabled() is False


### PR DESCRIPTION
## Summary

Adds optional API key authentication middleware for the HIRI admin API.

### Features
- **Configurable API key**: Set via `set_api_key()` or `HIRI_API_KEY` environment variable
- **Decorator-based**: `@require_auth` decorator protects any handler
- **Optional**: When no key is configured, all requests pass through (zero-config)
- **Standard Bearer token**: Expects `Authorization: Bearer <key>` header
- **Clear error responses**: 401 for missing header, 403 for wrong key

### Test coverage
- Auth disabled by default
- Auth enabled via set_api_key()
- Auth enabled via env var
- Valid key passes through
- Missing header → 401
- Wrong key → 403
- No auth when disabled → pass through
- Key persists until cleared

All 8 tests pass.

Fixes #19