### PR TITLE
feat(bridge): add --domain and --area filters to devices export CLI (Fixes #78)

### DIFF
--- a/packages/bridge/src/hiri_bridge/cli.py
+++ b/packages/bridge/src/hiri_bridge/cli.py
@@ -216,13 +216,36 @@ def devices_sim_history(
 @devices_app.command("export")
 def devices_export(
     out: Path = typer.Option(..., "--out", "-o", help="Output JSON file path"),
+    domain: str | None = typer.Option(None, "--domain", "-d", help="Filter by device domain"),
+    area: str | None = typer.Option(None, "--area", "-a", help="Filter by room/area"),
 ) -> None:
-    """Export device registry as a JSON snapshot (no tokens/secrets)."""
+    """Export device registry as a JSON snapshot (no tokens/secrets).
+
+    Optionally filter by --domain (e.g. light, sensor) and/or --area (e.g. living, farm).
+    """
     reg = _registry()
-    snapshot = [d.model_dump() for d in reg.list()]
+    devices = reg.list()
+
+    if domain:
+        devices = [d for d in devices if d.domain == domain]
+    if area:
+        devices = [
+            d
+            for d in devices
+            if str(getattr(d, "area", None) or (d.attributes or {}).get("area") or "").lower()
+            == area.strip().lower()
+        ]
+
+    snapshot = [d.model_dump() for d in devices]
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(json.dumps(snapshot, indent=2) + "\n", encoding="utf-8")
-    console.print(f"[green]Wrote[/green] {out} devices={len(snapshot)}")
+    filters = []
+    if domain:
+        filters.append(f"domain={domain}")
+    if area:
+        filters.append(f"area={area}")
+    tag = f" ({', '.join(filters)})" if filters else ""
+    console.print(f"[green]Wrote[/green] {out} devices={len(snapshot)}{tag}")
 
 
 @ha_app.command("discovery")

--- a/packages/bridge/src/hiri_bridge/cli.py
+++ b/packages/bridge/src/hiri_bridge/cli.py
@@ -218,10 +218,12 @@ def devices_export(
     out: Path = typer.Option(..., "--out", "-o", help="Output JSON file path"),
     domain: str | None = typer.Option(None, "--domain", "-d", help="Filter by device domain"),
     area: str | None = typer.Option(None, "--area", "-a", help="Filter by room/area"),
+    online_only: bool = typer.Option(False, "--online-only", help="Only export online devices"),
 ) -> None:
     """Export device registry as a JSON snapshot (no tokens/secrets).
 
-    Optionally filter by --domain (e.g. light, sensor) and/or --area (e.g. living, farm).
+    Optionally filter by --domain (e.g. light, sensor), --area (e.g. living, farm),
+    and/or --online-only.
     """
     reg = _registry()
     devices = reg.list()
@@ -235,6 +237,8 @@ def devices_export(
             if str(getattr(d, "area", None) or (d.attributes or {}).get("area") or "").lower()
             == area.strip().lower()
         ]
+    if online_only:
+        devices = [d for d in devices if getattr(d, "online", True)]
 
     snapshot = [d.model_dump() for d in devices]
     out.parent.mkdir(parents=True, exist_ok=True)
@@ -244,6 +248,8 @@ def devices_export(
         filters.append(f"domain={domain}")
     if area:
         filters.append(f"area={area}")
+    if online_only:
+        filters.append("online-only")
     tag = f" ({', '.join(filters)})" if filters else ""
     console.print(f"[green]Wrote[/green] {out} devices={len(snapshot)}{tag}")
 

--- a/packages/bridge/tests/test_devices_export.py
+++ b/packages/bridge/tests/test_devices_export.py
@@ -56,3 +56,72 @@ def test_devices_export_requires_out_option() -> None:
         text=True,
     )
     assert result.returncode != 0, "export without --out should fail"
+
+
+def test_devices_export_filter_by_domain(tmp_path: Path) -> None:
+    """export --domain light writes only light devices."""
+    out = tmp_path / "lights.json"
+    result = subprocess.run(
+        [sys.executable, "-m", "hiri_bridge.cli", "devices", "export",
+         "--out", str(out), "--domain", "light"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout} stderr={result.stderr}"
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert all(d["domain"] == "light" for d in data), f"Expected only lights, got domains: {[d['domain'] for d in data]}"
+    assert len(data) >= 1
+    assert "domain=light" in result.stdout
+
+
+def test_devices_export_filter_by_area(tmp_path: Path) -> None:
+    """export --area farm writes only farm devices."""
+    out = tmp_path / "farm.json"
+    result = subprocess.run(
+        [sys.executable, "-m", "hiri_bridge.cli", "devices", "export",
+         "--out", str(out), "--area", "farm"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout} stderr={result.stderr}"
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert len(data) >= 1
+    # All devices should be in farm area
+    for d in data:
+        area = str(d.get("area", "")).lower()
+        assert area == "farm", f"Expected area=farm, got {area} for {d['id']}"
+    assert "area=farm" in result.stdout
+
+
+def test_devices_export_filter_domain_and_area(tmp_path: Path) -> None:
+    """export --domain switch --area farm returns only farm switches."""
+    out = tmp_path / "farm_switches.json"
+    result = subprocess.run(
+        [sys.executable, "-m", "hiri_bridge.cli", "devices", "export",
+         "--out", str(out), "--domain", "switch", "--area", "farm"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout} stderr={result.stderr}"
+    data = json.loads(out.read_text(encoding="utf-8"))
+    for d in data:
+        assert d["domain"] == "switch"
+        area = str(d.get("area", "")).lower()
+        assert area == "farm", f"Expected farm, got {area}"
+    assert "domain=switch" in result.stdout
+    assert "area=farm" in result.stdout
+
+
+def test_devices_export_filter_domain_no_match(tmp_path: Path) -> None:
+    """export --domain nonexistent returns empty list."""
+    out = tmp_path / "empty.json"
+    result = subprocess.run(
+        [sys.executable, "-m", "hiri_bridge.cli", "devices", "export",
+         "--out", str(out), "--domain", "update"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data == []
+    assert "devices=0" in result.stdout

--- a/packages/bridge/tests/test_devices_export.py
+++ b/packages/bridge/tests/test_devices_export.py
@@ -125,3 +125,39 @@ def test_devices_export_filter_domain_no_match(tmp_path: Path) -> None:
     data = json.loads(out.read_text(encoding="utf-8"))
     assert data == []
     assert "devices=0" in result.stdout
+
+
+def test_devices_export_filter_online_only(tmp_path: Path) -> None:
+    """export --online-only returns only online devices."""
+    out = tmp_path / "online.json"
+    result = subprocess.run(
+        [sys.executable, "-m", "hiri_bridge.cli", "devices", "export",
+         "--out", str(out), "--online-only"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout} stderr={result.stderr}"
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert len(data) >= 1
+    # All devices should be online
+    for d in data:
+        assert d.get("online", True), f"Expected online=True, got {d.get('online')} for {d['id']}"
+    assert "online-only" in result.stdout
+
+
+def test_devices_export_filter_online_and_domain(tmp_path: Path) -> None:
+    """export --online-only --domain switch returns only online switches."""
+    out = tmp_path / "online_switches.json"
+    result = subprocess.run(
+        [sys.executable, "-m", "hiri_bridge.cli", "devices", "export",
+         "--out", str(out), "--online-only", "--domain", "switch"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout} stderr={result.stderr}"
+    data = json.loads(out.read_text(encoding="utf-8"))
+    for d in data:
+        assert d["domain"] == "switch"
+        assert d.get("online", True), f"Expected online=True for {d['id']}"
+    assert "domain=switch" in result.stdout
+    assert "online-only" in result.stdout


### PR DESCRIPTION
## 50 MRG

Enhances the existing `devices export` command with optional `--domain`, `--area`, and `--online-only` filters.

### New CLI options

| Option | Short | Description |
|--------|-------|-------------|
| `--domain` | `-d` | Filter by device domain (e.g. light, sensor, switch) |
| `--area` | `-a` | Filter by room/area (case-insensitive, e.g. living, farm) |
| `--online-only` | — | Only export devices with `online: true` |

### Changes
- **CLI**: Added `--domain`, `--area`, and `--online-only` optional parameters to `devices export`
- **Filtering**: Domain exact-match, area case-insensitive match (consistent with `devices list`), online boolean filter
- **Output**: Enhanced status line shows active filters (e.g. `devices=5 (domain=light, online-only)`)
- **Tests**: 9 tests total (3 base + 4 domain/area + 2 online-only)

### Usage examples
```bash
hiri-bridge devices export --out snapshot.json
hiri-bridge devices export --out lights.json --domain light
hiri-bridge devices export --out farm.json --area farm
hiri-bridge devices export --out online.json --online-only
hiri-bridge devices export --out filtered.json --domain switch --area farm --online-only
```

Fixes #78