### PR TITLE
feat: add devices filter --domain CLI (Closes #89)

### DIFF
--- a/src/hiri/devices_cli.py
+++ b/src/hiri/devices_cli.py
@@ -1,0 +1,98 @@
+"""CLI: hiri-bridge devices list --domain filter (Closes #89).
+
+Usage: python -m hiri.devices_cli list --domain sensor
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from collections import defaultdict
+
+
+DEVICES_DIR = Path(__file__).resolve().parent.parent.parent / "devices"
+
+
+def load_devices(devices_dir: Path = DEVICES_DIR):
+    """Load all device JSON files from directory."""
+    devices = []
+    for fpath in sorted(devices_dir.glob("*.json")):
+        try:
+            data = json.loads(fpath.read_text())
+            data["_source"] = fpath.name
+            devices.append(data)
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return devices
+
+
+def filter_by_domain(devices: list, domain: str) -> list:
+    """Filter devices by domain (e.g., 'sensor', 'light', 'switch')."""
+    if not domain:
+        return devices
+    return [d for d in devices if d.get("domain", "").lower() == domain.lower()]
+
+
+def list_domains(devices: list) -> dict:
+    """List all domains and their device counts."""
+    counts = defaultdict(int)
+    for d in devices:
+        domain = d.get("domain", "unknown")
+        counts[domain] += 1
+    return dict(sorted(counts.items()))
+
+
+def format_table(devices: list, columns: list[str] = None) -> str:
+    """Format devices as a readable table."""
+    if columns is None:
+        columns = ["entity_id", "domain", "state"]
+
+    if not devices:
+        return "No devices found."
+
+    col_widths = {c: max(len(c), max((len(str(d.get(c, ""))) for d in devices), default=0)) for c in columns}
+    header = " | ".join(c.ljust(col_widths[c]) for c in columns)
+    sep = "-+-".join("-" * col_widths[c] for c in columns)
+
+    rows = [header, sep]
+    for d in devices:
+        row = " | ".join(str(d.get(c, "")).ljust(col_widths[c]) for c in columns)
+        rows.append(row)
+
+    rows.append("")
+    rows.append("Total: {} devices".format(len(devices)))
+    return "\n".join(rows)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="HIRI Bridge devices CLI")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = sub.add_parser("list", help="List devices with optional domain filter")
+    list_parser.add_argument("--domain", type=str, help="Filter by domain (e.g., sensor, light, switch)")
+    list_parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+    domains_parser = sub.add_parser("domains", help="List all domains with device counts")
+
+    args = parser.parse_args()
+    devices = load_devices()
+
+    if args.command == "list":
+        filtered = filter_by_domain(devices, args.domain)
+        if args.json:
+            print(json.dumps(filtered, indent=2))
+        else:
+            print(format_table(filtered))
+        return 0
+
+    elif args.command == "domains":
+        domain_counts = list_domains(devices)
+        for domain, count in domain_counts.items():
+            print("  {} ({} devices)".format(domain, count))
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_devices_cli.py
+++ b/tests/test_devices_cli.py
@@ -1,0 +1,67 @@
+"""Tests for devices filter --domain CLI (Closes #89)."""
+import json
+import tempfile
+from pathlib import Path
+from src.hiri.devices_cli import load_devices, filter_by_domain, list_domains, format_table
+
+
+SAMPLE_DEVICES_DIR = Path(__file__).parent / "fixtures" / "devices"
+
+
+class TestFilterByDomain:
+    def make_device(self, entity_id, domain, state="on"):
+        return {"entity_id": entity_id, "domain": domain, "state": state}
+
+    def test_filter_matching_domain(self):
+        devices = [
+            self.make_device("sensor.temp", "sensor"),
+            self.make_device("light.kitchen", "light"),
+            self.make_device("sensor.humidity", "sensor"),
+        ]
+        filtered = filter_by_domain(devices, "sensor")
+        assert len(filtered) == 2
+        assert all(d["domain"] == "sensor" for d in filtered)
+
+    def test_filter_case_insensitive(self):
+        devices = [self.make_device("light.kitchen", "Light")]
+        filtered = filter_by_domain(devices, "light")
+        assert len(filtered) == 1
+
+    def test_filter_no_match(self):
+        devices = [self.make_device("switch.a", "switch")]
+        filtered = filter_by_domain(devices, "sensor")
+        assert len(filtered) == 0
+
+    def test_filter_empty_domain_returns_all(self):
+        devices = [self.make_device("a", "x"), self.make_device("b", "y")]
+        filtered = filter_by_domain(devices, "")
+        assert len(filtered) == 2
+
+
+class TestListDomains:
+    def test_counts_by_domain(self):
+        devices = [
+            {"entity_id": "a", "domain": "light"},
+            {"entity_id": "b", "domain": "light"},
+            {"entity_id": "c", "domain": "sensor"},
+        ]
+        counts = list_domains(devices)
+        assert counts["light"] == 2
+        assert counts["sensor"] == 1
+
+    def test_unknown_domain(self):
+        devices = [{"entity_id": "x"}]
+        counts = list_domains(devices)
+        assert counts["unknown"] == 1
+
+
+class TestFormatTable:
+    def test_non_empty_table(self):
+        devices = [{"entity_id": "light.a", "domain": "light", "state": "on"}]
+        table = format_table(devices)
+        assert "light.a" in table
+        assert "1 devices" in table
+
+    def test_empty_table(self):
+        table = format_table([])
+        assert "No devices" in table


### PR DESCRIPTION
## CLI: devices filter --domain (Closes #89)

Adds `hiri-bridge devices` CLI with domain filtering.

### Commands
- `python -m hiri.devices_cli list --domain sensor` — filter devices by domain
- `python -m hiri.devices_cli list --json` — JSON output
- `python -m hiri.devices_cli domains` — list all domains with counts

### Files
- src/hiri/devices_cli.py: CLI module with argparse
- tests/test_devices_cli.py: 7 tests covering filter, domain listing, table formatting

### Acceptance
- [x] CLI + tests